### PR TITLE
🔒 Fix path traversal vulnerability in fileSystem.ts

### DIFF
--- a/electron/fileSystem.ts
+++ b/electron/fileSystem.ts
@@ -51,7 +51,8 @@ export class FileSystemManager {
     if (!this.vaultPath) throw new Error('No vault path set');
     const resolved = path.resolve(this.vaultPath, relativePath);
     // Security: ensure resolved path is within vault
-    if (!resolved.startsWith(this.vaultPath)) {
+    const vaultWithSep = this.vaultPath.endsWith(path.sep) ? this.vaultPath : this.vaultPath + path.sep;
+    if (resolved !== this.vaultPath && !resolved.startsWith(vaultWithSep)) {
       throw new Error('Path traversal detected');
     }
     return resolved;
@@ -429,7 +430,8 @@ export class FileSystemManager {
     try {
       const dir = this.ensureDataDir();
       const filePath = path.join(dir, relativePath);
-      if (!filePath.startsWith(dir)) throw new Error('Path traversal detected');
+      const dirWithSep = dir.endsWith(path.sep) ? dir : dir + path.sep;
+      if (filePath !== dir && !filePath.startsWith(dirWithSep)) throw new Error('Path traversal detected');
       if (!fs.existsSync(filePath)) return null;
       return await fs.promises.readFile(filePath, 'utf-8');
     } catch {
@@ -441,7 +443,8 @@ export class FileSystemManager {
   async writeDataFile(relativePath: string, content: string): Promise<void> {
     const dir = this.ensureDataDir();
     const filePath = path.join(dir, relativePath);
-    if (!filePath.startsWith(dir)) throw new Error('Path traversal detected');
+    const dirWithSep = dir.endsWith(path.sep) ? dir : dir + path.sep;
+    if (filePath !== dir && !filePath.startsWith(dirWithSep)) throw new Error('Path traversal detected');
     const fileDir = path.dirname(filePath);
     if (!fs.existsSync(fileDir)) {
       fs.mkdirSync(fileDir, { recursive: true });
@@ -454,7 +457,8 @@ export class FileSystemManager {
     try {
       const dir = this.ensureDataDir();
       const filePath = path.join(dir, relativePath);
-      if (!filePath.startsWith(dir)) return;
+      const dirWithSep = dir.endsWith(path.sep) ? dir : dir + path.sep;
+      if (filePath !== dir && !filePath.startsWith(dirWithSep)) return;
       if (fs.existsSync(filePath)) {
         await fs.promises.unlink(filePath);
       }


### PR DESCRIPTION
### What
A path traversal vulnerability exists in the `resolvePath` and data file methods in `electron/fileSystem.ts`.

### Risk
The validation logic incorrectly relies on `startsWith` which can be bypassed. For example, if a vault is located at `/app/vault`, a malicious path could be constructed to access `/app/vault-secrets` because both share the same `/app/vault` prefix string. This allows for unauthorized file access out of the intended scope.

### Solution
The `startsWith` check has been replaced with a more strict directory overlap check that appends `path.sep` to the end of the compared vault and data directories to explicitly prevent bypasses.

I am preparing a PR with the fix for this issue.

Closes: #29 


