### PR TITLE
fix: prevent multiple instances and default to dark theme

### DIFF
--- a/electron/main.ts
+++ b/electron/main.ts
@@ -41,7 +41,6 @@ const MAX_RECENT_VAULTS = 20;
 
 const singleInstanceLock = app.requestSingleInstanceLock();
 if (!singleInstanceLock) {
-  app.quit();
   app.exit(0);
 }
 

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -39,6 +39,12 @@ let searchEngine: SearchEngine | null = null;
 const isDevMode = !app.isPackaged;
 const MAX_RECENT_VAULTS = 20;
 
+const singleInstanceLock = app.requestSingleInstanceLock();
+if (!singleInstanceLock) {
+  app.quit();
+  app.exit(0);
+}
+
 type VaultHistoryState = {
   currentVaultPath: string | null;
   previousVaultPaths: string[];
@@ -647,6 +653,18 @@ app.whenReady().then(() => {
       createWindow();
     }
   });
+});
+
+app.on('second-instance', () => {
+  if (!mainWindow) {
+    createWindow();
+    return;
+  }
+
+  if (mainWindow.isMinimized()) {
+    mainWindow.restore();
+  }
+  mainWindow.focus();
 });
 
 app.on('window-all-closed', () => {

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -41,7 +41,7 @@ const MAX_RECENT_VAULTS = 20;
 
 const singleInstanceLock = app.requestSingleInstanceLock();
 if (!singleInstanceLock) {
-  app.quit();
+  app.exit(0);
 }
 
 type VaultHistoryState = {

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -41,7 +41,7 @@ const MAX_RECENT_VAULTS = 20;
 
 const singleInstanceLock = app.requestSingleInstanceLock();
 if (!singleInstanceLock) {
-  app.exit(0);
+  app.quit();
 }
 
 type VaultHistoryState = {
@@ -655,15 +655,23 @@ app.whenReady().then(() => {
 });
 
 app.on('second-instance', () => {
-  if (!mainWindow) {
-    createWindow();
+  if (!mainWindow || mainWindow.isDestroyed()) {
     return;
   }
 
   if (mainWindow.isMinimized()) {
     mainWindow.restore();
   }
+
+  if (!mainWindow.isVisible()) {
+    mainWindow.show();
+  }
+
   mainWindow.focus();
+
+  if (process.platform === 'darwin') {
+    app.focus({ steal: true });
+  }
 });
 
 app.on('window-all-closed', () => {

--- a/src/components/settings/SettingsPage.tsx
+++ b/src/components/settings/SettingsPage.tsx
@@ -118,7 +118,7 @@ export interface AppSettings {
 }
 
 export const DEFAULT_SETTINGS: AppSettings = {
-  theme: "light",
+  theme: "dark",
   accentColor: "#2563eb",
   fontFamily: "Inter, system-ui, sans-serif",
   customBgPrimary: "#151515",


### PR DESCRIPTION
## Summary

- Prevent multiple OpenOnyx Electron instances using app.requestSingleInstanceLock()
- Focus the existing window when a second instance is launched
- Change the default application theme from light to dark

## Validation

- npm run lint ✅
- npm run build ✅

Closes #60