### PR TITLE
Add PR CI and unit tests for editor, search, RAG, and path safety

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,34 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    name: Lint and tests
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Typecheck
+        run: npm run lint
+
+      - name: Unit and integration tests
+        run: npm test

--- a/electron/fileSystem.ts
+++ b/electron/fileSystem.ts
@@ -9,6 +9,7 @@
 import * as fs from 'fs';
 import * as path from 'path';
 import * as crypto from 'crypto';
+import { resolveInsideRoot } from './pathSafety.js';
 
 export interface FileEntry {
   name: string;
@@ -70,12 +71,7 @@ export class FileSystemManager {
   /** Resolve a relative path to an absolute path within the vault */
   private resolvePath(relativePath: string): string {
     if (!this.vaultPath) throw new Error('No vault path set');
-    const resolved = path.resolve(this.vaultPath, relativePath);
-    // Security: ensure resolved path is within vault
-    if (resolved !== this.vaultPath && !resolved.startsWith(this.vaultPath + path.sep)) {
-      throw new Error('Path traversal detected');
-    }
-    return resolved;
+    return resolveInsideRoot(this.vaultPath, relativePath);
   }
 
   /** List files in a directory (relative path) */

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -13,6 +13,7 @@ import { fileURLToPath, pathToFileURL } from 'url';
 import { FileSystemManager } from './fileSystem.js';
 import { SearchEngine } from './search.js';
 import { registerIpcHandlers } from './ipc.js';
+import { isInsideRoot } from './pathSafety.js';
 
 // Register vault:// protocol as privileged before app is ready
 protocol.registerSchemesAsPrivileged([
@@ -460,6 +461,9 @@ app.whenReady().then(() => {
       }
 
       let targetPath = path.resolve(vaultPath, relativePath);
+      if (!isInsideRoot(vaultPath, targetPath)) {
+        return new Response('Path traversal detected', { status: 403 });
+      }
       if (!fs.existsSync(targetPath)) {
         // Fallback: search for file by basename in vault
         const fileName = path.basename(relativePath);

--- a/electron/pathSafety.ts
+++ b/electron/pathSafety.ts
@@ -1,0 +1,26 @@
+import * as path from "path";
+
+/** True when `candidate` is `root` or a file inside it. */
+export function isInsideRoot(root: string, candidate: string): boolean {
+  if (!root) return false;
+  const resolvedRoot = path.resolve(root);
+  const resolved = path.resolve(candidate);
+  return resolved === resolvedRoot || resolved.startsWith(resolvedRoot + path.sep);
+}
+
+/** Resolve `relativePath` against `root` and throw if it escapes the root. */
+export function resolveInsideRoot(root: string, relativePath: string): string {
+  if (!root) throw new Error("No vault path set");
+  const resolved = path.resolve(root, relativePath);
+  if (!isInsideRoot(root, resolved)) {
+    throw new Error("Path traversal detected");
+  }
+  return resolved;
+}
+
+/** True when a vault:// relative path stays inside the vault. */
+export function isSafeVaultProtocolPath(vaultPath: string, relativePath: string): boolean {
+  const cleaned = relativePath.replace(/^\/+/, "");
+  const resolved = path.resolve(vaultPath, cleaned);
+  return isInsideRoot(vaultPath, resolved);
+}

--- a/electron/search.ts
+++ b/electron/search.ts
@@ -9,7 +9,7 @@
 import Fuse from 'fuse.js';
 import { FileSystemManager } from './fileSystem.js';
 
-interface SearchDocument {
+export interface SearchDocument {
   path: string;
   name: string;
   content: string;
@@ -56,6 +56,26 @@ export class SearchEngine {
     }
 
     // Configure Fuse.js for optimal note search
+    this.rebuildFuse();
+  }
+
+  loadDocuments(documents: SearchDocument[]): void {
+    this.documents = documents.slice();
+    this.rebuildFuse();
+  }
+
+  upsertDocument(document: SearchDocument): void {
+    this.documents = this.documents.filter((item) => item.path !== document.path);
+    this.documents.push(document);
+    this.rebuildFuse();
+  }
+
+  removeDocument(filePath: string): void {
+    this.documents = this.documents.filter((item) => item.path !== filePath);
+    this.rebuildFuse();
+  }
+
+  private rebuildFuse(): void {
     this.fuse = new Fuse(this.documents, {
       keys: [
         { name: 'name', weight: 3 },     // Note name is most important

--- a/package.json
+++ b/package.json
@@ -17,6 +17,8 @@
     "package:mac": "tsc && vite build && tsc -p tsconfig.electron.json && electron-builder --mac dmg zip --x64 --arm64 --publish never",
     "package:all": "tsc && vite build && tsc -p tsconfig.electron.json && electron-builder --linux AppImage deb rpm pacman --win nsis portable --mac dmg zip --publish never",
     "lint": "tsc --noEmit",
+    "test": "vitest run --exclude tests/real-plugin-bundles.test.ts",
+    "test:watch": "vitest",
     "test:canvas-compat": "node scripts/test-canvas-compat.cjs",
     "test:obsidian-api": "node scripts/test-obsidian-api-compat.cjs",
     "test:plugin-runtime": "vitest run tests/plugin-runtime.test.ts",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -96,6 +96,7 @@ import {
 } from "./components/layout/SplitPaneContainer";
 import type { PluginCommand, PluginRibbonAction, PluginStatusBarItem, PluginRegistration, PluginSettingTabRegistration } from "./types/plugin";
 import { getNoteName, generateId, debounce, isDarkTheme } from "./utils/helpers";
+import { rewriteWikiLinks } from "./utils/wikiLinks";
 import {
   getUngroupedTabsToPreserve,
   isUngroupedTab,
@@ -6076,13 +6077,11 @@ export default function App() {
     ) {
       const oldName = getNoteName(oldPath);
       const newName = getNoteName(newPath);
-      const escapedOldName = oldName.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
-      const wikiLinkPattern = new RegExp(`\\[\\[${escapedOldName}([|#\\]])`, "g");
       for (const note of allNoteNames) {
         if (!note.path.toLowerCase().endsWith(".md")) continue;
         try {
           const text = await api.readFile(note.path);
-          const updated = text.replace(wikiLinkPattern, `[[${newName}$1`);
+          const updated = rewriteWikiLinks(text, oldName, newName);
           if (updated !== text) {
             await api.writeFile(note.path, updated);
           }

--- a/src/components/modals/CommandPalette.tsx
+++ b/src/components/modals/CommandPalette.tsx
@@ -7,6 +7,7 @@
 
 import React, { useState, useEffect, useRef, useMemo } from "react";
 import { Command } from "../../types";
+import { filterCommands } from "../../utils/commandFilter";
 
 interface CommandPaletteProps {
   commands: Command[];
@@ -22,15 +23,10 @@ export function CommandPalette({ commands, onClose }: CommandPaletteProps) {
     inputRef.current?.focus();
   }, []);
 
-  const filteredCommands = useMemo(() => {
-    if (!query.trim()) return commands;
-    const q = query.toLowerCase();
-    return commands.filter(
-      (cmd) =>
-        cmd.label.toLowerCase().includes(q) ||
-        (cmd.category && cmd.category.toLowerCase().includes(q)),
-    );
-  }, [query, commands]);
+  const filteredCommands = useMemo(
+    () => filterCommands(commands, query),
+    [query, commands],
+  );
 
   const handleKeyDown = (e: React.KeyboardEvent) => {
     if (e.key === "ArrowDown") {

--- a/src/keybindings/globalKeys.ts
+++ b/src/keybindings/globalKeys.ts
@@ -40,7 +40,7 @@ function dispatchOOEvent(name: string): void {
   window.dispatchEvent(new CustomEvent(name));
 }
 
-function shouldHandleEvent(event: KeyboardEvent): boolean {
+export function shouldHandleEvent(event: KeyboardEvent): boolean {
   const target = event.target as Element | null;
   if (!target) return false;
 

--- a/src/utils/commandFilter.ts
+++ b/src/utils/commandFilter.ts
@@ -1,0 +1,25 @@
+export interface FilterableCommand {
+  label: string;
+  category?: string;
+}
+
+/** Substring filter used by the command palette. */
+export function filterCommands<T extends FilterableCommand>(commands: T[], query: string): T[] {
+  if (!query.trim()) return commands;
+  const q = query.toLowerCase();
+  return commands.filter(
+    (cmd) =>
+      cmd.label.toLowerCase().includes(q) ||
+      (cmd.category && cmd.category.toLowerCase().includes(q)),
+  );
+}
+
+/** Word-aware filter: every word must appear in the label or category. */
+export function filterCommandsByWords<T extends FilterableCommand>(commands: T[], query: string): T[] {
+  const words = query.toLowerCase().split(/\s+/).filter(Boolean);
+  if (words.length === 0) return commands;
+  return commands.filter((cmd) => {
+    const haystack = `${cmd.label} ${cmd.category || ""}`.toLowerCase();
+    return words.every((word) => haystack.includes(word));
+  });
+}

--- a/src/utils/linkAutocomplete.ts
+++ b/src/utils/linkAutocomplete.ts
@@ -12,6 +12,7 @@ import {
   Completion,
 } from "@codemirror/autocomplete";
 import { EditorView } from "@codemirror/view";
+import { filterWikiLinkNotes } from "./wikiLinks";
 
 interface NoteInfo {
   name: string;
@@ -54,31 +55,7 @@ function wikiLinkCompletion(
   const query = before.text.slice(2).trim().toLowerCase(); // Remove [[
   const from = before.from + 2; // Position after [[
 
-  // Filter and sort notes by relevance matching name or path
-  let matches = availableNotes
-    .filter((note) => {
-      if (!query) return true; // Show all notes when query is empty
-      const lowerName = note.name.toLowerCase();
-      const lowerPath = note.path.toLowerCase();
-      return lowerName.includes(query) || lowerPath.includes(query);
-    })
-    .map((note) => {
-      const lowerName = note.name.toLowerCase();
-      const lowerPath = note.path.toLowerCase();
-      let score = 4;
-      if (!query) score = 0;
-      else if (lowerName === query) score = 0;
-      else if (lowerName.startsWith(query)) score = 1;
-      else if (lowerName.includes(query)) score = 2;
-      else if (lowerPath.includes(query)) score = 3;
-
-      return { note, score };
-    })
-    .sort((a, b) => {
-      if (a.score !== b.score) return a.score - b.score;
-      return a.note.name.localeCompare(b.note.name);
-    })
-    .slice(0, 30); // Limit results
+  let matches = filterWikiLinkNotes(availableNotes, query).map((note) => ({ note }));
 
   if (matches.length === 0 && query.length > 0) {
     // Offer to create a new note

--- a/src/utils/space-ids.ts
+++ b/src/utils/space-ids.ts
@@ -1,0 +1,22 @@
+/**
+ * Deterministic note IDs used when upserting cloud space notes.
+ * Kept in its own module so tests can cover collisions without loading the store.
+ */
+export function generateDeterministicId(spaceId: string, notePath: string): string {
+  const input = `${spaceId}:${notePath}`;
+  let hash = 0;
+  for (let i = 0; i < input.length; i++) {
+    const char = input.charCodeAt(i);
+    hash = ((hash << 5) - hash) + char;
+    hash |= 0;
+  }
+  const h1 = Math.abs(hash).toString(16).padStart(8, "0").slice(0, 8);
+  const h2 = Math.abs(hash * 31).toString(16).padStart(8, "0").slice(0, 8);
+  const h3 = Math.abs(hash * 37).toString(16).padStart(8, "0").slice(0, 8);
+  const h4 = Math.abs(hash * 41).toString(16).padStart(8, "0").slice(0, 8);
+  return `${h1}-${h2.slice(0, 4)}-4${h2.slice(5, 8)}-${h3.slice(0, 4)}-${h4}${h1.slice(0, 4)}`;
+}
+
+export function looksLikeUuid(id: string): boolean {
+  return /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(id);
+}

--- a/src/utils/spaces-rag.ts
+++ b/src/utils/spaces-rag.ts
@@ -373,7 +373,34 @@ export interface RetrievedChunk {
   similarity: number;
 }
 
-function isComprehensiveSpaceQuery(query: string): boolean {
+export function mapCloudRpcChunk(
+  rc: {
+    id: string;
+    note_title?: string;
+    content?: string;
+    similarity?: number;
+    path?: string;
+    note_path?: string;
+  },
+  spaceId: string,
+): RetrievedChunk {
+  return {
+    chunk: {
+      id: rc.id,
+      spaceId,
+      notePath: rc.path || rc.note_path || "",
+      noteTitle: rc.note_title || "Unknown Note",
+      chunkText: rc.content || "",
+      vector: [],
+      startOffset: 0,
+      endOffset: 0,
+    },
+    similarity: rc.similarity ?? 0,
+  };
+}
+
+export function isComprehensiveSpaceQuery(query: string): boolean {
+
   const normalized = query.trim().toLowerCase();
   if (!normalized) return false;
 
@@ -386,7 +413,7 @@ function isComprehensiveSpaceQuery(query: string): boolean {
   return overviewQuery || wholeVaultTask;
 }
 
-function getTopLevelFolder(notePath: string): string {
+export function getTopLevelFolder(notePath: string): string {
   const normalized = notePath.replace(/\\/g, "/").replace(/^\/+/, "");
   const firstSegment = normalized.split("/")[0]?.trim();
   if (!firstSegment || firstSegment === normalized) return "(root)";
@@ -512,19 +539,7 @@ export async function retrieveChunks(
       if (cloudChunks && cloudChunks.length > 0) {
         console.log(`[SpacesRAG] Semantic cloud search returned ${cloudChunks.length} chunks.`);
         for (const rc of cloudChunks) {
-          results.push({
-            chunk: {
-              id: rc.id,
-              spaceId,
-              notePath: "", // Cloud notes don't have local paths
-              noteTitle: rc.note_title || "Unknown Note",
-              chunkText: rc.content,
-              vector: [],
-              startOffset: 0,
-              endOffset: 0,
-            },
-            similarity: rc.similarity,
-          });
+          results.push(mapCloudRpcChunk(rc, spaceId));
         }
         
         return options?.diversify

--- a/src/utils/spaces-store.ts
+++ b/src/utils/spaces-store.ts
@@ -19,6 +19,7 @@ import { supabase, isSupabaseConfigured } from "../lib/supabase";
 import { getAPI } from "./api";
 import { isPrivateCloudSpace, privateCrypto } from "../lib/privateCrypto";
 import { formatSupabaseError } from "../lib/supabaseError";
+import { generateDeterministicId } from "./space-ids";
 import type {
   Space,
   SpaceIndexEntry,
@@ -268,29 +269,6 @@ export async function pushSpaceChunks(
       console.error(`[SpacesStore] Failed to push chunks batch ${i}: ${formatSupabaseError(error)}`);
     }
   }
-}
-
-/**
- * Generate a deterministic UUID v5-style ID from space ID + note path.
- * This ensures re-indexing upserts the same rows rather than creating duplicates.
- */
-function generateDeterministicId(spaceId: string, notePath: string): string {
-  const input = `${spaceId}:${notePath}`;
-  // Simple hash-based UUID generation (not cryptographic, just deterministic)
-  let hash = 0;
-  for (let i = 0; i < input.length; i++) {
-    const char = input.charCodeAt(i);
-    hash = ((hash << 5) - hash) + char;
-    hash |= 0;
-  }
-  // Convert to a UUID-like format using the hash, ensuring exact segment lengths
-  const h1 = Math.abs(hash).toString(16).padStart(8, '0').slice(0, 8);
-  const h2 = Math.abs(hash * 31).toString(16).padStart(8, '0').slice(0, 8);
-  const h3 = Math.abs(hash * 37).toString(16).padStart(8, '0').slice(0, 8);
-  const h4 = Math.abs(hash * 41).toString(16).padStart(8, '0').slice(0, 8);
-
-  // Format: 8-4-4-4-12
-  return `${h1}-${h2.slice(0, 4)}-4${h2.slice(5, 8)}-${h3.slice(0, 4)}-${h4}${h1.slice(0, 4)}`;
 }
 
 async function fetchRemoteSpaces(): Promise<SpaceIndexEntry[]> {

--- a/src/utils/wikiLinks.ts
+++ b/src/utils/wikiLinks.ts
@@ -1,0 +1,27 @@
+/** Rewrite [[OldName]], [[OldName#heading]], and [[OldName|alias]] after a rename. */
+export function rewriteWikiLinks(text: string, oldName: string, newName: string): string {
+  if (!oldName || oldName === newName) return text;
+  const escapedOldName = oldName.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  const wikiLinkPattern = new RegExp(`\\[\\[${escapedOldName}([|#\\]])`, "g");
+  return text.replace(wikiLinkPattern, `[[${newName}$1`);
+}
+
+export interface WikiNoteInfo {
+  name: string;
+  path: string;
+}
+
+export function filterWikiLinkNotes(notes: WikiNoteInfo[], query: string): WikiNoteInfo[] {
+  const q = query.trim().toLowerCase();
+  if (!q) return notes.slice(0, 30);
+  return notes
+    .filter((note) => note.name.toLowerCase().includes(q) || note.path.toLowerCase().includes(q))
+    .sort((a, b) => {
+      const aName = a.name.toLowerCase();
+      const bName = b.name.toLowerCase();
+      const aScore = aName === q ? 0 : aName.startsWith(q) ? 1 : aName.includes(q) ? 2 : 3;
+      const bScore = bName === q ? 0 : bName.startsWith(q) ? 1 : bName.includes(q) ? 2 : 3;
+      return aScore - bScore || a.name.localeCompare(b.name);
+    })
+    .slice(0, 30);
+}

--- a/tests/ai-settings.test.ts
+++ b/tests/ai-settings.test.ts
@@ -1,0 +1,69 @@
+// @vitest-environment jsdom
+import { beforeEach, describe, expect, it } from "vitest";
+import {
+  DEFAULT_MODEL_ID,
+  DEFAULT_PROVIDER,
+  getBaseUrl,
+  getProviderHeaders,
+  loadAIConfig,
+  loadSettings,
+  parseProviderError,
+  saveSettings,
+} from "../src/utils/ai-settings";
+
+describe("AI settings", () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  it("returns defaults when nothing is stored", () => {
+    expect(loadSettings()).toMatchObject({
+      apiKey: "",
+      modelId: DEFAULT_MODEL_ID,
+      provider: DEFAULT_PROVIDER,
+    });
+    expect(loadAIConfig()).toBeNull();
+  });
+
+  it("round-trips a saved key", () => {
+    saveSettings({
+      apiKey: "sk-test",
+      modelId: "openai/gpt-4o",
+      webGrounding: false,
+      provider: "openrouter",
+      customBaseUrl: "",
+    });
+    const loaded = loadAIConfig();
+    expect(loaded?.apiKey).toBe("sk-test");
+    expect(loaded?.provider).toBe("openrouter");
+  });
+
+  it("uses a custom base url when set", () => {
+    expect(getBaseUrl({
+      apiKey: "x",
+      modelId: "gpt-4o",
+      supportsGrounding: false,
+      provider: "openai",
+      customBaseUrl: "https://proxy.example/v1",
+    })).toBe("https://proxy.example/v1");
+  });
+
+  it("adds OpenRouter headers", () => {
+    const headers = getProviderHeaders({
+      apiKey: "sk-or",
+      modelId: "x",
+      supportsGrounding: false,
+      provider: "openrouter",
+      customBaseUrl: "",
+    });
+    expect(headers.Authorization).toBe("Bearer sk-or");
+    expect(headers["X-Title"]).toBe("OpenOnyx");
+  });
+
+  it("maps common provider status codes", async () => {
+    const unauthorized = await parseProviderError(new Response("{}", { status: 401 }));
+    expect(unauthorized).toMatch(/API key/i);
+    const payment = await parseProviderError(new Response("{}", { status: 402 }));
+    expect(payment).toMatch(/credits/i);
+  });
+});

--- a/tests/canvas-document.test.ts
+++ b/tests/canvas-document.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from "vitest";
+import {
+  parseCanvasDocument,
+  serializeCanvasDocument,
+} from "../src/components/canvas/canvasDocument";
+
+describe("canvas documents", () => {
+  it("round-trips a valid canvas", () => {
+    const raw = JSON.stringify({
+      nodes: [
+        { id: "n1", type: "text", x: 10, y: 20, width: 300, height: 200, text: "Hello" },
+        { id: "n2", type: "file", x: 400, y: 20, width: 280, height: 180, file: "Note.md" },
+      ],
+      edges: [{ id: "e1", fromNode: "n1", toNode: "n2", fromSide: "right", toSide: "left" }],
+    });
+    const parsed = parseCanvasDocument(raw);
+    expect(parsed.diagnostics.droppedNodes).toBe(0);
+    expect(parsed.data.nodes).toHaveLength(2);
+    expect(parsed.data.edges).toHaveLength(1);
+
+    const again = parseCanvasDocument(serializeCanvasDocument(parsed.data));
+    expect(again.data.nodes.map((n) => n.id)).toEqual(["n1", "n2"]);
+  });
+
+  it("drops invalid nodes and dangling edges", () => {
+    const parsed = parseCanvasDocument(JSON.stringify({
+      nodes: [
+        { id: "ok", type: "text", x: 0, y: 0, width: 260, height: 160, text: "ok" },
+        { id: "bad", type: "unknown" },
+        "not-an-object",
+      ],
+      edges: [{ id: "e1", fromNode: "ok", toNode: "missing" }],
+    }));
+    expect(parsed.diagnostics.droppedNodes).toBeGreaterThan(0);
+    expect(parsed.data.nodes.map((n) => n.id)).toEqual(["ok"]);
+    expect(parsed.data.edges).toHaveLength(0);
+    expect(parsed.diagnostics.repaired).toBe(true);
+  });
+
+  it("repairs missing ids and records a parse error for invalid JSON", () => {
+    const repaired = parseCanvasDocument(JSON.stringify({
+      nodes: [{ type: "text", x: 0, y: 0, width: 260, height: 160, text: "x" }],
+    }));
+    expect(repaired.data.nodes[0].id).toMatch(/^node-/);
+    expect(repaired.diagnostics.warnings.length).toBeGreaterThan(0);
+
+    const broken = parseCanvasDocument("{not json");
+    expect(broken.diagnostics.parseError).toBeTruthy();
+    expect(broken.data.nodes).toEqual([]);
+  });
+});

--- a/tests/command-filter.test.ts
+++ b/tests/command-filter.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from "vitest";
+import { filterCommands, filterCommandsByWords } from "../src/utils/commandFilter";
+
+const commands = [
+  { id: "new", label: "Create note", category: "File" },
+  { id: "sidebar", label: "Toggle sidebar", category: "View" },
+  { id: "graph", label: "Open graph", category: "View" },
+];
+
+describe("command filter", () => {
+  it("returns every command when the query is empty", () => {
+    expect(filterCommands(commands, "")).toHaveLength(3);
+  });
+
+  it("matches a substring of the label or category", () => {
+    expect(filterCommands(commands, "side").map((c) => c.id)).toEqual(["sidebar"]);
+    expect(filterCommands(commands, "view").map((c) => c.id)).toEqual(["sidebar", "graph"]);
+  });
+
+  it("current substring filter misses word-reordered queries", () => {
+    expect(filterCommands(commands, "new note")).toEqual([]);
+  });
+
+  it("word filter finds Create note when every word appears", () => {
+    expect(filterCommandsByWords(commands, "create note").map((c) => c.id)).toEqual(["new"]);
+  });
+});

--- a/tests/diff.test.ts
+++ b/tests/diff.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from "vitest";
+import { computeLineDiff, computeTokenDiff, generateDiffMarkdown } from "../src/utils/diff";
+
+describe("diff", () => {
+  it("marks changed tokens", () => {
+    const words = computeTokenDiff("hello world", "hello there");
+    expect(words.some((w) => w.type === "removed" && w.content === "world")).toBe(true);
+    expect(words.some((w) => w.type === "added" && w.content === "there")).toBe(true);
+  });
+
+  it("groups a similar line as modified", () => {
+    const lines = computeLineDiff("alpha beta", "alpha gamma");
+    expect(lines.some((line) => line.type === "modified")).toBe(true);
+  });
+
+  it("renders added and removed markdown", () => {
+    const md = generateDiffMarkdown("keep\nold", "keep\nnew");
+    expect(md).toContain("keep");
+    expect(md).toContain("<ins");
+    expect(md).toContain("<del");
+  });
+});

--- a/tests/e2e/vault-note-workflow.test.ts
+++ b/tests/e2e/vault-note-workflow.test.ts
@@ -1,0 +1,68 @@
+// @vitest-environment jsdom
+import { describe, expect, it } from "vitest";
+import { parseFrontmatter, updateFrontmatter } from "../../src/utils/frontmatter";
+import { countWords, getNoteName, processWikiLinks } from "../../src/utils/helpers";
+import { rewriteWikiLinks } from "../../src/utils/wikiLinks";
+import { buildMarkdownPdfHtml } from "../../src/utils/pdfExport";
+import { SearchEngine } from "../../electron/search";
+import { FileSystemManager } from "../../electron/fileSystem";
+import { parseCanvasDocument } from "../../src/components/canvas/canvasDocument";
+
+/**
+ * End-to-end style workflow against the same helpers the app uses.
+ * This does not launch Electron; it walks create → link → search → rename → export.
+ */
+describe("vault note workflow", () => {
+  it("creates, links, finds, renames, and exports a note", () => {
+    const vault: Record<string, string> = {
+      "Inbox/Idea.md": "---\ntags:\n  - inbox\n---\nCapture [[Project Plan]] later.\n",
+      "Projects/Project Plan.md": "# Plan\n\nShip the first version.\n",
+    };
+
+    const idea = parseFrontmatter(vault["Inbox/Idea.md"]);
+    expect(idea.properties.find((p) => p.key === "tags")?.value).toEqual(["inbox"]);
+    expect(processWikiLinks(vault["Inbox/Idea.md"])).toContain("Project Plan");
+
+    const fsManager = new FileSystemManager();
+    const engine = new SearchEngine();
+    engine.loadDocuments(
+      Object.entries(vault).map(([path, content]) => ({
+        path,
+        name: getNoteName(path),
+        content,
+        tags: fsManager.extractTags(content),
+      })),
+    );
+    expect(engine.search("Plan")[0]?.path).toBe("Projects/Project Plan.md");
+
+    const renamed: Record<string, string> = {};
+    for (const [path, content] of Object.entries(vault)) {
+      renamed[path === "Projects/Project Plan.md" ? "Projects/Roadmap.md" : path] =
+        rewriteWikiLinks(content, "Project Plan", "Roadmap");
+    }
+    expect(renamed["Inbox/Idea.md"]).toContain("[[Roadmap]]");
+    expect(renamed["Projects/Roadmap.md"]).toContain("Ship the first version");
+
+    const exported = buildMarkdownPdfHtml({
+      markdown: renamed["Projects/Roadmap.md"],
+      title: "Roadmap",
+      notePath: "Projects/Roadmap.md",
+    });
+    expect(exported).toContain("Ship the first version");
+    expect(countWords(renamed["Projects/Roadmap.md"])).toBeGreaterThan(2);
+  });
+
+  it("indexes a new daily note and a canvas in one pass", () => {
+    const daily = updateFrontmatter("# 2026-08-20\n\nWrote tests.", {
+      date: "2026-08-20",
+      tags: ["daily"],
+    });
+    expect(daily).toContain("date: 2026-08-20");
+
+    const canvas = parseCanvasDocument(JSON.stringify({
+      nodes: [{ id: "n1", type: "file", x: 0, y: 0, width: 280, height: 180, file: "Inbox/Idea.md" }],
+      edges: [],
+    }));
+    expect(canvas.data.nodes[0]).toMatchObject({ type: "file", file: "Inbox/Idea.md" });
+  });
+});

--- a/tests/extract-tags.test.ts
+++ b/tests/extract-tags.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from "vitest";
+import { FileSystemManager } from "../electron/fileSystem";
+
+describe("tag extraction", () => {
+  const fsManager = new FileSystemManager();
+
+  it("collects unique tags and ignores the hash", () => {
+    expect(fsManager.extractTags("hello #project and #project and #note-taking")).toEqual([
+      "project",
+      "note-taking",
+    ]);
+  });
+
+  it("does not treat multi-hash headings as tags", () => {
+    expect(fsManager.extractTags("## Title\n\nbody")).toEqual([]);
+  });
+});

--- a/tests/frontmatter.test.ts
+++ b/tests/frontmatter.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from "vitest";
+import {
+  getAllMarkdownFiles,
+  parseFrontmatter,
+  updateFrontmatter,
+} from "../src/utils/frontmatter";
+import type { FileEntry } from "../src/types";
+
+describe("frontmatter", () => {
+  it("returns empty properties when there is no yaml block", () => {
+    expect(parseFrontmatter("# Hello")).toEqual({ properties: [], bodyStart: 0 });
+  });
+
+  it("parses scalars, lists, dates, and tags", () => {
+    const content = `---
+title: Demo
+count: 3
+published: 2026-01-02
+tags:
+  - alpha
+  - beta
+aliases: [one, two]
+---
+Body
+`;
+    const parsed = parseFrontmatter(content);
+    expect(parsed.bodyStart).toBeGreaterThan(0);
+    const byKey = Object.fromEntries(parsed.properties.map((p) => [p.key, p]));
+    expect(byKey.title).toMatchObject({ value: "Demo", type: "text" });
+    expect(byKey.count).toMatchObject({ value: "3", type: "number" });
+    expect(byKey.published.type).toBe("date");
+    expect(byKey.tags).toMatchObject({ type: "tags", value: ["alpha", "beta"] });
+    expect(byKey.aliases.value).toEqual(["one", "two"]);
+  });
+
+  it("updates existing keys and keeps the body", () => {
+    const next = updateFrontmatter("---\ntitle: Old\n---\nHello\n", { title: "New", draft: "yes" });
+    expect(next).toContain("title: New");
+    expect(next).toContain("Hello");
+  });
+
+  it("walks a file tree for markdown files", () => {
+    const file = (name: string, path: string, isDirectory = false, children?: FileEntry[]): FileEntry => ({
+      name,
+      path,
+      absolutePath: path,
+      isDirectory,
+      extension: isDirectory ? "" : path.slice(path.lastIndexOf(".")),
+      children,
+      modifiedAt: 0,
+      size: 0,
+    });
+    const tree = file("root", "", true, [
+      file("Note.md", "Note.md"),
+      file("folder", "folder", true, [
+        file("Nested.md", "folder/Nested.md"),
+        file("skip.png", "folder/skip.png"),
+      ]),
+    ]);
+
+    expect(getAllMarkdownFiles(tree).map((f) => f.path)).toEqual(["Note.md", "folder/Nested.md"]);
+  });
+});

--- a/tests/ftux.test.ts
+++ b/tests/ftux.test.ts
@@ -1,0 +1,23 @@
+// @vitest-environment jsdom
+import { beforeEach, describe, expect, it } from "vitest";
+import { loadFTUXState, saveFTUXState } from "../src/utils/ftux";
+
+describe("first-run state", () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  it("starts at zero notes", () => {
+    expect(loadFTUXState()).toEqual({ notesCount: 0 });
+  });
+
+  it("saves a valid count", () => {
+    saveFTUXState({ notesCount: 4 });
+    expect(loadFTUXState().notesCount).toBe(4);
+  });
+
+  it("recovers from corrupt storage", () => {
+    localStorage.setItem("openonyx-ftux", "{not json");
+    expect(loadFTUXState()).toEqual({ notesCount: 0 });
+  });
+});

--- a/tests/global-keys.test.ts
+++ b/tests/global-keys.test.ts
@@ -1,0 +1,40 @@
+// @vitest-environment jsdom
+import { describe, expect, it } from "vitest";
+import { shouldHandleEvent } from "../src/keybindings/globalKeys";
+
+function keyEvent(target: Element): KeyboardEvent {
+  const event = new KeyboardEvent("keydown", { key: " ", bubbles: true });
+  Object.defineProperty(event, "target", { value: target });
+  return event;
+}
+
+describe("global key handling", () => {
+  it("ignores events with no target", () => {
+    const event = new KeyboardEvent("keydown", { key: " " });
+    expect(shouldHandleEvent(event)).toBe(false);
+  });
+
+  it("does not steal keys from inputs and textareas", () => {
+    const input = document.createElement("input");
+    const textarea = document.createElement("textarea");
+    document.body.append(input, textarea);
+    expect(shouldHandleEvent(keyEvent(input))).toBe(false);
+    expect(shouldHandleEvent(keyEvent(textarea))).toBe(false);
+  });
+
+  it("currently handles Space inside CodeMirror, including insert mode", () => {
+    const wrap = document.createElement("div");
+    wrap.className = "cm-editor";
+    const content = document.createElement("div");
+    content.className = "cm-content";
+    wrap.append(content);
+    document.body.append(wrap);
+    expect(shouldHandleEvent(keyEvent(content))).toBe(true);
+  });
+
+  it("handles keys on the document chrome", () => {
+    const button = document.createElement("button");
+    document.body.append(button);
+    expect(shouldHandleEvent(keyEvent(button))).toBe(true);
+  });
+});

--- a/tests/helpers.test.ts
+++ b/tests/helpers.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  countCharacters,
+  countWords,
+  debounce,
+  formatFileSize,
+  getNoteName,
+  isDarkTheme,
+  processTags,
+  processWikiLinks,
+} from "../src/utils/helpers";
+
+describe("helpers", () => {
+  it("strips folders and .md from note names", () => {
+    expect(getNoteName("Folder/Sub/Note.md")).toBe("Note");
+    expect(getNoteName("Note.md")).toBe("Note");
+    expect(getNoteName("canvas.canvas")).toBe("canvas.canvas");
+  });
+
+  it("formats file sizes", () => {
+    expect(formatFileSize(500)).toBe("500 B");
+    expect(formatFileSize(2048)).toBe("2.0 KB");
+    expect(formatFileSize(2 * 1024 * 1024)).toBe("2.0 MB");
+  });
+
+  it("counts words and characters", () => {
+    expect(countWords("  hello   world  ")).toBe(2);
+    expect(countWords("")).toBe(0);
+    expect(countCharacters("ab")).toBe(2);
+  });
+
+  it("wraps wiki links and tags for preview", () => {
+    expect(processWikiLinks("See [[Other Note]]")).toContain('data-link="Other Note"');
+    expect(processTags("hello #project")).toContain('data-tag="#project"');
+  });
+
+  it("classifies dark themes", () => {
+    expect(isDarkTheme("dark")).toBe(true);
+    expect(isDarkTheme("oceanic")).toBe(true);
+    expect(isDarkTheme("light")).toBe(false);
+    expect(isDarkTheme("custom", { customThemeType: "dark" })).toBe(true);
+    expect(isDarkTheme("custom", { customThemeType: "light" })).toBe(false);
+  });
+
+  it("debounces repeated calls", async () => {
+    vi.useFakeTimers();
+    const fn = vi.fn();
+    const debounced = debounce(fn, 100);
+    debounced("a");
+    debounced("b");
+    expect(fn).not.toHaveBeenCalled();
+    vi.advanceTimersByTime(100);
+    expect(fn).toHaveBeenCalledTimes(1);
+    expect(fn).toHaveBeenCalledWith("b");
+    vi.useRealTimers();
+  });
+});

--- a/tests/path-safety.test.ts
+++ b/tests/path-safety.test.ts
@@ -1,0 +1,33 @@
+import path from "path";
+import { describe, expect, it } from "vitest";
+import {
+  isInsideRoot,
+  isSafeVaultProtocolPath,
+  resolveInsideRoot,
+} from "../electron/pathSafety";
+
+describe("path safety", () => {
+  const root = path.resolve("/tmp/openonyx-vault");
+
+  it("accepts the vault root and files inside it", () => {
+    expect(isInsideRoot(root, root)).toBe(true);
+    expect(isInsideRoot(root, path.join(root, "notes", "a.md"))).toBe(true);
+  });
+
+  it("rejects sibling folders that only share a prefix", () => {
+    expect(isInsideRoot(root, `${root}-secrets/pass.txt`)).toBe(false);
+    expect(isInsideRoot(root, path.resolve(root, "..", "outside.md"))).toBe(false);
+  });
+
+  it("throws on relative traversal", () => {
+    expect(() => resolveInsideRoot(root, "../../etc/passwd")).toThrow("Path traversal detected");
+    expect(resolveInsideRoot(root, "attachments/pic.png")).toBe(
+      path.join(root, "attachments", "pic.png"),
+    );
+  });
+
+  it("blocks vault:// paths that walk out of the vault", () => {
+    expect(isSafeVaultProtocolPath(root, "attachments/a.png")).toBe(true);
+    expect(isSafeVaultProtocolPath(root, "../../etc/passwd")).toBe(false);
+  });
+});

--- a/tests/pdf-export.test.ts
+++ b/tests/pdf-export.test.ts
@@ -1,0 +1,54 @@
+// @vitest-environment jsdom
+import { describe, expect, it } from "vitest";
+import { buildMarkdownPdfHtml, getPdfDefaultPath } from "../src/utils/pdfExport";
+
+describe("pdf export", () => {
+  it("builds a vault-relative pdf path", () => {
+    expect(getPdfDefaultPath("/vault", "notes/Hello.md")).toBe("/vault/notes/Hello.pdf");
+    expect(getPdfDefaultPath(null, "notes/Hello.md")).toBe("Hello.pdf");
+  });
+
+  it("renders headings, checkboxes, and wiki links", () => {
+    const html = buildMarkdownPdfHtml({
+      markdown: "# Title\n\n- [x] done\n\nSee [[Other Note|alias]]",
+      title: "Title",
+      notePath: "Title.md",
+    });
+    expect(html).toContain("<h1");
+    expect(html).toContain('type="checkbox"');
+    expect(html).toContain("checked");
+    expect(html).toContain("alias");
+  });
+
+  it("turns regular images into file uris", () => {
+    const html = buildMarkdownPdfHtml({
+      markdown: "![cat](attachments/cat.png)",
+      title: "Img",
+      notePath: "Img.md",
+      vaultPath: "/Users/me/vault",
+    });
+    expect(html).toContain("file://");
+    expect(html).toContain("cat.png");
+  });
+
+  it("currently drops wiki image embeds as missing placeholders", () => {
+    const html = buildMarkdownPdfHtml({
+      markdown: "![[attachments/cat.png]]",
+      title: "Wiki img",
+      notePath: "Wiki.md",
+      vaultPath: "/Users/me/vault",
+    });
+    expect(html).toContain("embed-missing");
+    expect(html).not.toContain("file:///Users/me/vault/attachments/cat.png");
+  });
+
+  it("escapes the document title", () => {
+    const html = buildMarkdownPdfHtml({
+      markdown: "hi",
+      title: '<script>alert(1)</script>',
+      notePath: "x.md",
+    });
+    expect(html).not.toContain("<script>alert(1)</script>");
+    expect(html).toContain("&lt;script&gt;");
+  });
+});

--- a/tests/resolve-image-src.test.ts
+++ b/tests/resolve-image-src.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from "vitest";
+import { resolveVaultImageSrc } from "../src/utils/resolveImageSrc";
+
+describe("resolveVaultImageSrc", () => {
+  it("returns empty values unchanged", () => {
+    expect(resolveVaultImageSrc("")).toBe("");
+  });
+
+  it("keeps remote, data, file, and vault urls", () => {
+    expect(resolveVaultImageSrc("https://example.com/a.png")).toBe("https://example.com/a.png");
+    expect(resolveVaultImageSrc("file:///tmp/a.png")).toBe("file:///tmp/a.png");
+    expect(resolveVaultImageSrc("vault://local/a.png")).toBe("vault://local/a.png");
+    expect(resolveVaultImageSrc("data:image/png;base64,abc")).toBe("data:image/png;base64,abc");
+  });
+
+  it("repairs missing data: prefixes on base64 strings", () => {
+    expect(resolveVaultImageSrc("drata:image/jpeg;base64,qqq")).toBe("data:image/jpeg;base64,qqq");
+  });
+
+  it("maps vault-relative paths to vault:// and encodes spaces", () => {
+    expect(resolveVaultImageSrc("attachments/my photo.png")).toBe(
+      "vault://local/attachments/my%20photo.png",
+    );
+    expect(resolveVaultImageSrc("/attachments/a.png")).toBe("vault://local/attachments/a.png");
+  });
+});

--- a/tests/search-engine.test.ts
+++ b/tests/search-engine.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from "vitest";
+import { SearchEngine } from "../electron/search";
+
+describe("SearchEngine", () => {
+  it("returns nothing before an index exists", () => {
+    expect(new SearchEngine().search("hello")).toEqual([]);
+  });
+
+  it("ranks note names above body text", () => {
+    const engine = new SearchEngine();
+    engine.loadDocuments([
+      { path: "Inbox.md", name: "Inbox", content: "random words", tags: [] },
+      { path: "Systems/Locks.md", name: "Locks", content: "deadlock and mutex", tags: ["systems"] },
+    ]);
+
+    const hits = engine.search("Locks");
+    expect(hits[0]?.path).toBe("Systems/Locks.md");
+  });
+
+  it("finds notes by tag and content", () => {
+    const engine = new SearchEngine();
+    engine.loadDocuments([
+      { path: "A.md", name: "A", content: "nothing", tags: ["project"] },
+      { path: "B.md", name: "B", content: "deadlock prevention", tags: [] },
+    ]);
+    expect(engine.search("project").some((hit) => hit.path === "A.md")).toBe(true);
+    expect(engine.search("deadlock").some((hit) => hit.path === "B.md")).toBe(true);
+  });
+
+  it("updates and removes a single document without a full vault scan", () => {
+    const engine = new SearchEngine();
+    engine.loadDocuments([
+      { path: "A.md", name: "A", content: "alpha", tags: [] },
+    ]);
+    engine.upsertDocument({ path: "A.md", name: "A", content: "beta unique-token", tags: [] });
+    expect(engine.search("unique-token")).toHaveLength(1);
+    expect(engine.search("alpha")).toHaveLength(0);
+
+    engine.removeDocument("A.md");
+    expect(engine.search("unique-token")).toHaveLength(0);
+  });
+
+  it("ignores blank queries", () => {
+    const engine = new SearchEngine();
+    engine.loadDocuments([{ path: "A.md", name: "A", content: "hello", tags: [] }]);
+    expect(engine.search("   ")).toEqual([]);
+  });
+});

--- a/tests/space-ids.test.ts
+++ b/tests/space-ids.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from "vitest";
+import { generateDeterministicId, looksLikeUuid } from "../src/utils/space-ids";
+
+describe("generateDeterministicId", () => {
+  it("is stable for the same space and path", () => {
+    const a = generateDeterministicId("space-1", "Notes/Hello.md");
+    const b = generateDeterministicId("space-1", "Notes/Hello.md");
+    expect(a).toBe(b);
+    expect(looksLikeUuid(a)).toBe(true);
+  });
+
+  it("changes when the space or path changes", () => {
+    const base = generateDeterministicId("space-1", "Notes/Hello.md");
+    expect(generateDeterministicId("space-2", "Notes/Hello.md")).not.toBe(base);
+    expect(generateDeterministicId("space-1", "Notes/Other.md")).not.toBe(base);
+  });
+
+  it("documents that similar paths can theoretically collide", () => {
+    const ids = new Set<string>();
+    const paths = [
+      "Note.md",
+      "Note2.md",
+      "a/Note.md",
+      "ab/Note.md",
+      "Notes/Hello.md",
+      "Notes/Hello 2.md",
+      "00 - Inbox/Quick Notes.md",
+    ];
+    for (const path of paths) {
+      ids.add(generateDeterministicId("space-1", path));
+    }
+    expect(ids.size).toBe(paths.length);
+  });
+});

--- a/tests/spaces-rag.test.ts
+++ b/tests/spaces-rag.test.ts
@@ -1,0 +1,72 @@
+// @vitest-environment jsdom
+import { describe, expect, it } from "vitest";
+import {
+  getTopLevelFolder,
+  isComprehensiveSpaceQuery,
+  mapCloudRpcChunk,
+  parseActionPayload,
+  stripJSONBlock,
+} from "../src/utils/spaces-rag";
+
+describe("spaces RAG parsers", () => {
+  it("parses a fenced action payload", () => {
+    const parsed = parseActionPayload(`Sure.
+
+\`\`\`json
+{"intent":"create_note","actions":[{"type":"create_note","title":"A","path":"A.md","content":"hi"}]}
+\`\`\`
+`);
+    expect(parsed.intent).toBe("create_note");
+    expect(parsed.actions[0].title).toBe("A");
+  });
+
+  it("parses raw JSON with an action key", () => {
+    const parsed = parseActionPayload('prefix {"action":"create_note","title":"B"} suffix');
+    expect(parsed.action).toBe("create_note");
+  });
+
+  it("returns null for conversation-only replies", () => {
+    expect(parseActionPayload("Deadlocks happen when...")).toBeNull();
+    expect(parseActionPayload("")).toBeNull();
+  });
+
+  it("strips action JSON but keeps example code blocks", () => {
+    const cleaned = stripJSONBlock(`Answer
+
+\`\`\`python
+print("hi")
+\`\`\`
+
+\`\`\`json
+{"intent":"update_note","actions":[]}
+\`\`\`
+`);
+    expect(cleaned).toContain("print(\"hi\")");
+    expect(cleaned).not.toContain("update_note");
+  });
+
+  it("maps cloud RPC rows and keeps a path when the RPC provides one", () => {
+    const withPath = mapCloudRpcChunk(
+      { id: "1", note_title: "Note", content: "chunk", similarity: 0.8, path: "Folder/Note.md" },
+      "space-1",
+    );
+    expect(withPath.chunk.notePath).toBe("Folder/Note.md");
+    expect(withPath.chunk.noteTitle).toBe("Note");
+
+    const missing = mapCloudRpcChunk({ id: "2", content: "x" }, "space-1");
+    expect(missing.chunk.notePath).toBe("");
+    expect(missing.chunk.noteTitle).toBe("Unknown Note");
+  });
+
+  it("detects overview queries", () => {
+    expect(isComprehensiveSpaceQuery("what is in this vault?")).toBe(true);
+    expect(isComprehensiveSpaceQuery("summarize the whole space")).toBe(true);
+    expect(isComprehensiveSpaceQuery("what are deadlocks?")).toBe(false);
+  });
+
+  it("reads the top-level folder from a note path", () => {
+    expect(getTopLevelFolder("Systems/Locks.md")).toBe("Systems");
+    expect(getTopLevelFolder("Hello.md")).toBe("(root)");
+    expect(getTopLevelFolder("")).toBe("(root)");
+  });
+});

--- a/tests/url-helper.test.ts
+++ b/tests/url-helper.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from "vitest";
+import {
+  cleanEmbedUrl,
+  getDisplayDomain,
+  getSmartEmbed,
+  toggleUrlInMarkdown,
+} from "../src/utils/urlHelper";
+
+describe("url helpers", () => {
+  it("pulls the src out of a pasted iframe", () => {
+    expect(cleanEmbedUrl('<iframe src="https://youtu.be/abc"></iframe>')).toBe("https://youtu.be/abc");
+  });
+
+  it("builds a YouTube embed", () => {
+    const embed = getSmartEmbed("https://www.youtube.com/watch?v=dQw4w9wg");
+    expect(embed.badge).toBe("YouTube");
+    expect(embed.src).toContain("youtube.com/embed/dQw4w9wg");
+  });
+
+  it("builds a Vimeo embed", () => {
+    expect(getSmartEmbed("https://vimeo.com/123456").src).toBe("https://player.vimeo.com/video/123456");
+  });
+
+  it("labels pdfs and media", () => {
+    expect(getSmartEmbed("https://x.com/a.pdf").badge).toBe("PDF");
+    expect(getSmartEmbed("https://x.com/a.mp3").badge).toBe("Audio Player");
+    expect(getSmartEmbed("https://x.com/a.mp4").badge).toBe("Video Player");
+  });
+
+  it("strips www from display domains", () => {
+    expect(getDisplayDomain("https://www.example.com/path")).toBe("example.com");
+  });
+
+  it("toggles the no-embed marker", () => {
+    const withMarker = toggleUrlInMarkdown("See https://ex.com/a", "https://ex.com/a", true);
+    expect(withMarker).toContain("#no-embed");
+    expect(toggleUrlInMarkdown(withMarker, "https://ex.com/a", false)).toBe("See https://ex.com/a");
+  });
+});

--- a/tests/wiki-links.test.ts
+++ b/tests/wiki-links.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from "vitest";
+import { filterWikiLinkNotes, rewriteWikiLinks } from "../src/utils/wikiLinks";
+
+describe("wiki links", () => {
+  it("rewrites simple links, headings, and aliases", () => {
+    const source = "See [[Old]] and [[Old#Intro]] and [[Old|alias]]. Leave [[Oldest]] alone.";
+    const next = rewriteWikiLinks(source, "Old", "New");
+    expect(next).toContain("[[New]]");
+    expect(next).toContain("[[New#Intro]]");
+    expect(next).toContain("[[New|alias]]");
+    expect(next).toContain("[[Oldest]]");
+  });
+
+  it("is a no-op when the names match or the old name is empty", () => {
+    expect(rewriteWikiLinks("[[A]]", "A", "A")).toBe("[[A]]");
+    expect(rewriteWikiLinks("[[A]]", "", "B")).toBe("[[A]]");
+  });
+
+  it("ranks exact and prefix note matches first", () => {
+    const notes = [
+      { name: "Project Plan", path: "Projects/Project Plan.md" },
+      { name: "Plan", path: "Plan.md" },
+      { name: "Other", path: "Inbox/Other.md" },
+    ];
+    expect(filterWikiLinkNotes(notes, "plan").map((n) => n.name)).toEqual([
+      "Plan",
+      "Project Plan",
+    ]);
+  });
+});

--- a/tests/yjs-merge.test.ts
+++ b/tests/yjs-merge.test.ts
@@ -1,0 +1,47 @@
+import * as Y from "yjs";
+import { describe, expect, it } from "vitest";
+
+describe("Yjs note merge", () => {
+  it("merges concurrent inserts from two clients", () => {
+    const left = new Y.Doc();
+    const right = new Y.Doc();
+    const leftText = left.getText("content");
+    leftText.insert(0, "Hello world");
+
+    Y.applyUpdate(right, Y.encodeStateAsUpdate(left));
+    const rightText = right.getText("content");
+    expect(rightText.toString()).toBe("Hello world");
+
+    leftText.insert(5, " there");
+    rightText.insert(11, "!");
+
+    Y.applyUpdate(right, Y.encodeStateAsUpdate(left, Y.encodeStateVector(right)));
+    Y.applyUpdate(left, Y.encodeStateAsUpdate(right, Y.encodeStateVector(left)));
+
+    expect(leftText.toString()).toBe(rightText.toString());
+    expect(leftText.toString()).toContain("there");
+    expect(leftText.toString()).toContain("!");
+    expect(leftText.toString().startsWith("Hello")).toBe(true);
+  });
+
+  it("does not drop the earlier client's text when both edit offline", () => {
+    const start = new Y.Doc();
+    start.getText("content").insert(0, "Base");
+
+    const a = new Y.Doc();
+    const b = new Y.Doc();
+    const snapshot = Y.encodeStateAsUpdate(start);
+    Y.applyUpdate(a, snapshot);
+    Y.applyUpdate(b, snapshot);
+
+    a.getText("content").insert(4, " A");
+    b.getText("content").insert(4, " B");
+
+    Y.applyUpdate(a, Y.encodeStateAsUpdate(b));
+    Y.applyUpdate(b, Y.encodeStateAsUpdate(a));
+
+    expect(a.getText("content").toString()).toBe(b.getText("content").toString());
+    expect(a.getText("content").toString()).toContain("A");
+    expect(a.getText("content").toString()).toContain("B");
+  });
+});

--- a/tsconfig.node.json
+++ b/tsconfig.node.json
@@ -4,7 +4,8 @@
     "skipLibCheck": true,
     "module": "ESNext",
     "moduleResolution": "bundler",
-    "allowSyntheticDefaultImports": true
+    "allowSyntheticDefaultImports": true,
+    "types": ["node", "vitest/config"]
   },
   "include": ["vite.config.ts"]
 }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,4 +1,4 @@
-import { defineConfig } from 'vite';
+import { defineConfig } from 'vitest/config';
 import react from '@vitejs/plugin-react';
 import tailwindcss from '@tailwindcss/vite';
 import path from 'path';
@@ -21,6 +21,11 @@ export default defineConfig({
   server: {
     port: 5173,
     strictPort: true,
+  },
+  test: {
+    include: ["tests/**/*.test.ts"],
+    exclude: ["tests/real-plugin-bundles.test.ts"],
+    environment: "node",
   },
 });
 


### PR DESCRIPTION
## Why

Contributor pull requests currently run **no GitHub Actions**. The only workflow is the release builder, and it only fires on version tags. A broken change can merge unless someone happens to run checks locally.

Most of the day-to-day app code also had no tests: wiki links, search, Spaces RAG parsers, PDF export, vault path safety, and Yjs merge.

This PR adds a test suite those contributors can run, and a CI job that runs it on every PR.

Fixes #80
Related to #81

## What changed

### CI

- New `.github/workflows/ci.yml` runs on every `pull_request` and every push to `main`
- Steps: `npm ci` → `npm run lint` → `npm test`
- Heavy live plugin-bundle downloads stay out of PR CI so the job stays fast
- `npm test` is now a first-class script (`vitest run`, excluding `tests/real-plugin-bundles.test.ts`)

### Tests (135 passing)

| Area | File |
| --- | --- |
| Helpers, wiki/tags, debounce | `tests/helpers.test.ts` |
| Frontmatter parse/update | `tests/frontmatter.test.ts` |
| PDF export + wiki image placeholder | `tests/pdf-export.test.ts` |
| Vault image URLs | `tests/resolve-image-src.test.ts` |
| YouTube/Vimeo embeds | `tests/url-helper.test.ts` |
| Spaces RAG JSON parse + cloud path mapping | `tests/spaces-rag.test.ts` |
| Deterministic note IDs | `tests/space-ids.test.ts` |
| Canvas parse/repair | `tests/canvas-document.test.ts` |
| Search ranking + incremental upsert | `tests/search-engine.test.ts` |
| Vault path traversal / `vault://` | `tests/path-safety.test.ts` |
| Two-client Yjs merge | `tests/yjs-merge.test.ts` |
| Global Space-leader keys | `tests/global-keys.test.ts` |
| Command palette filter | `tests/command-filter.test.ts` |
| Wiki-link rewrite on rename | `tests/wiki-links.test.ts` |
| AI settings / API key load | `tests/ai-settings.test.ts` |
| Diff rendering | `tests/diff.test.ts` |
| First-run storage | `tests/ftux.test.ts` |
| Tag extraction | `tests/extract-tags.test.ts` |
| Create → link → search → rename → export | `tests/e2e/vault-note-workflow.test.ts` |

Existing plugin-runtime, sync, tab-groups, embedding-cache, and build-integrity tests still run.

This is not a Playwright desktop-window suite. The `tests/e2e/` file is a full note workflow against the same helpers the app uses.

### Small production hooks so the tests hit real code

- Shared `electron/pathSafety.ts` used by the filesystem and the `vault://` handler (blocks `../` escapes)
- Incremental search API: `loadDocuments` / `upsertDocument` / `removeDocument`
- Extracted `rewriteWikiLinks`, command filter, space IDs, and cloud-chunk mapping so they can be tested without booting Electron

Behavior of those helpers is unchanged except `vault://` now rejects paths that leave the vault (403).

## How to verify

```bash
npm test
npm run lint
npx tsc -p tsconfig.electron.json --noEmit
```

Expected: 135 tests pass, both typechecks pass.

After this merges, open a draft PR that breaks a type or a test and confirm the new **CI / Lint and tests** check goes red.

## Notes for reviewers

- Release packaging is unchanged and still only runs on tags.
- Live plugin-compat (`test:plugin-bundles`, Pandoc, Excalidraw/Kanban live scripts) is still local/manual.