### PR TITLE
fix: render wiki image embeds in PDF export

### DIFF
--- a/src/components/layout/LeafPaneEditor.tsx
+++ b/src/components/layout/LeafPaneEditor.tsx
@@ -1139,12 +1139,14 @@ export function LeafPaneEditor({
 
     try {
       const vaultPath = await api.getVaultPath();
+      const vaultFiles = vaultPath ? await api.getFileTree().catch(() => undefined) : undefined;
       const markdown = latestContentRef.current || content;
       const html = buildMarkdownPdfHtml({
         markdown,
         title: activeTab.name || activeTab.path.replace(/\.md$/i, ""),
         notePath: activeTab.path,
         vaultPath: vaultPath || undefined,
+        vaultFiles,
       });
       const result = await api.exportMarkdownPdf({
         html,

--- a/src/utils/pdfExport.ts
+++ b/src/utils/pdfExport.ts
@@ -1,6 +1,7 @@
 import { marked } from "marked";
 import markedKatex from "marked-katex-extension";
 import DOMPurify from "dompurify";
+import { resolveVaultImageSrc } from "./resolveImageSrc";
 
 marked.use(markedKatex({ throwOnError: false }));
 
@@ -26,14 +27,26 @@ function toFileUri(vaultPath: string | undefined, src: string): string {
   return `file://${joined.split("/").map((part, index) => index === 0 ? part : encodeURIComponent(part)).join("/")}`;
 }
 
+function isImageEmbedPath(src: string): boolean {
+  return /\.(png|jpe?g|gif|webp|svg|avif|bmp)(?:[?#].*)?$/i.test(src.trim());
+}
+
 function preprocessMarkdown(markdown: string, vaultPath?: string): string {
   let processed = stripFrontmatter(markdown);
 
   processed = processed.replace(
     /!\[\[([^\]|#]+)(?:#([^\]|]+))?(?:\|([^\]]+))?\]\]/g,
     (_match, noteName, heading, displayText) => {
-      const label = displayText || noteName;
-      return `<div class="embed-missing">${escapeHtml(label)}${heading ? ` / ${escapeHtml(heading)}` : ""}</div>`;
+      const src = String(noteName).trim();
+      const label = displayText || src;
+
+      if (isImageEmbedPath(src)) {
+        const resolvedSrc = resolveVaultImageSrc(src);
+        return `<img src="${escapeHtml(resolvedSrc)}" alt="${escapeHtml(label)}">`;
+      }
+
+      const labelText = displayText || src;
+      return `<div class="embed-missing">${escapeHtml(labelText)}${heading ? ` / ${escapeHtml(heading)}` : ""}</div>`;
     },
   );
 
@@ -86,7 +99,7 @@ export function buildMarkdownPdfHtml({
     ADD_TAGS: ["input", "math", "semantics", "mrow", "mi", "mo", "mn", "msup", "mspace", "msqrt", "mfrac", "annotation"],
     ADD_ATTR: ["checked", "disabled", "type", "style", "viewBox", "fill", "stroke", "stroke-width", "stroke-linecap", "stroke-linejoin"],
     ADD_DATA_URI_TAGS: ["img"],
-    ALLOWED_URI_REGEXP: /^(?:(?:(?:f|ht)tps?|file|data|mailto):|[^a-z]|[a-z+.\-]+(?:[^a-z+.\-:]|$))/i,
+    ALLOWED_URI_REGEXP: /^(?:(?:(?:f|ht)tps?|file|data|mailto|vault):|[^a-z]|[a-z+.\-]+(?:[^a-z+.\-:]|$))/i,
   });
 
   const safeTitle = escapeHtml(title || notePath.replace(/\.md$/i, ""));

--- a/src/utils/pdfExport.ts
+++ b/src/utils/pdfExport.ts
@@ -31,18 +31,92 @@ function isImageEmbedPath(src: string): boolean {
   return /\.(png|jpe?g|gif|webp|svg|avif|bmp)(?:[?#].*)?$/i.test(src.trim());
 }
 
-function preprocessMarkdown(markdown: string, vaultPath?: string): string {
+type VaultFileLike = {
+  path?: string;
+  name?: string;
+  isDirectory?: boolean;
+  children?: VaultFileLike[];
+};
+
+function normalizeVaultPath(value: string): string {
+  return value.replace(/\\/g, "/").replace(/^\/+/, "").replace(/\/+/g, "/");
+}
+
+function flattenVaultFiles(files: VaultFileLike[] | undefined): VaultFileLike[] | undefined {
+  if (!files) return undefined;
+
+  const flattened: VaultFileLike[] = [];
+  const visit = (entries: VaultFileLike[]) => {
+    for (const entry of entries) {
+      flattened.push(entry);
+      if (entry.children) visit(entry.children);
+    }
+  };
+  visit(files);
+  return flattened;
+}
+
+function parseWikiImageDisplay(displayText: string | undefined): { alt: string | null; width: number | null } {
+  if (!displayText) return { alt: null, width: null };
+
+  const parts = displayText.split("|").map((part) => part.trim()).filter(Boolean);
+  let width: number | null = null;
+  const altParts: string[] = [];
+
+  for (const part of parts) {
+    if (/^\d+$/.test(part) && width === null) {
+      width = Number(part);
+    } else {
+      altParts.push(part);
+    }
+  }
+
+  return {
+    alt: altParts.length > 0 ? altParts.join(" | ") : null,
+    width,
+  };
+}
+
+function preprocessMarkdown(markdown: string, vaultPath?: string, vaultFiles?: VaultFileLike[]): string {
   let processed = stripFrontmatter(markdown);
+  const flattenedVaultFiles = flattenVaultFiles(vaultFiles);
+  const existingPaths = new Set<string>();
+  const existingBasenames = new Set<string>();
+
+  if (flattenedVaultFiles) {
+    for (const file of flattenedVaultFiles) {
+      if (file.isDirectory) continue;
+
+      const filePath = file.path ? normalizeVaultPath(file.path) : "";
+      const fileName = file.name || filePath.split("/").pop();
+
+      if (filePath) existingPaths.add(filePath);
+      if (fileName) existingBasenames.add(fileName);
+    }
+  }
 
   processed = processed.replace(
     /!\[\[([^\]|#]+)(?:#([^\]|]+))?(?:\|([^\]]+))?\]\]/g,
     (_match, noteName, heading, displayText) => {
       const src = String(noteName).trim();
-      const label = displayText || src;
+      const { alt, width } = parseWikiImageDisplay(displayText);
+      const label = alt || src;
 
       if (isImageEmbedPath(src)) {
+        const normalizedSrc = normalizeVaultPath(src);
+        const srcBasename = normalizedSrc.split("/").pop();
+        const exists =
+          !vaultFiles ||
+          existingPaths.has(normalizedSrc) ||
+          (!!srcBasename && existingBasenames.has(srcBasename));
+
+        if (!exists) {
+          return `<div class="embed-missing">${escapeHtml(src)}</div>`;
+        }
+
         const resolvedSrc = resolveVaultImageSrc(src);
-        return `<img src="${escapeHtml(resolvedSrc)}" alt="${escapeHtml(label)}">`;
+        const style = width ? ` style="max-width: ${width}px; width: 100%;"` : "";
+        return `<img src="${escapeHtml(resolvedSrc)}" alt="${escapeHtml(label)}" title="${escapeHtml(label)}"${style}>`;
       }
 
       const labelText = displayText || src;
@@ -87,13 +161,15 @@ export function buildMarkdownPdfHtml({
   title,
   notePath,
   vaultPath,
+  vaultFiles,
 }: {
   markdown: string;
   title: string;
   notePath: string;
   vaultPath?: string;
+  vaultFiles?: VaultFileLike[];
 }): string {
-  const processed = preprocessMarkdown(markdown, vaultPath);
+  const processed = preprocessMarkdown(markdown, vaultPath, vaultFiles);
   const rendered = marked.parse(processed, { gfm: true, breaks: true }) as string;
   const safeHtml = DOMPurify.sanitize(rendered, {
     ADD_TAGS: ["input", "math", "semantics", "mrow", "mi", "mo", "mn", "msup", "mspace", "msqrt", "mfrac", "annotation"],

--- a/tests/pdf-export.test.ts
+++ b/tests/pdf-export.test.ts
@@ -31,15 +31,22 @@ describe("pdf export", () => {
     expect(html).toContain("cat.png");
   });
 
-  it("currently drops wiki image embeds as missing placeholders", () => {
+  it("renders wiki image embeds as printable vault protocol images", () => {
     const html = buildMarkdownPdfHtml({
-      markdown: "![[attachments/cat.png]]",
-      title: "Wiki img",
-      notePath: "Wiki.md",
-      vaultPath: "/Users/me/vault",
+      markdown: [
+        "![[attachments/demo.png]]",
+        "![regular](regular.png)",
+        "![[Missing Note]]",
+      ].join("\n\n"),
+      title: "Image Export",
+      notePath: "Image Export.md",
+      vaultPath: "/Users/example/My Vault",
     });
-    expect(html).toContain("embed-missing");
-    expect(html).not.toContain("file:///Users/me/vault/attachments/cat.png");
+
+    expect(html).toContain('src="vault://local/attachments/demo.png"');
+    expect(html).toContain('alt="attachments/demo.png"');
+    expect(html).toContain('src="file:///Users/example/My%20Vault/regular.png"');
+    expect(html).toContain('<div class="embed-missing">Missing Note</div>');
   });
 
   it("escapes the document title", () => {

--- a/tests/pdf-export.test.ts
+++ b/tests/pdf-export.test.ts
@@ -35,16 +35,31 @@ describe("pdf export", () => {
     const html = buildMarkdownPdfHtml({
       markdown: [
         "![[attachments/demo.png]]",
+        "![[diagram.png|300]]",
+        "![[photo.jpg|300|Alt text]]",
+        "![[missing.png]]",
         "![regular](regular.png)",
         "![[Missing Note]]",
       ].join("\n\n"),
       title: "Image Export",
       notePath: "Image Export.md",
       vaultPath: "/Users/example/My Vault",
+      vaultFiles: [
+        { path: "attachments/demo.png", name: "demo.png", isDirectory: false },
+        { path: "assets/nested/diagram.png", name: "diagram.png", isDirectory: false },
+        { path: "photo.jpg", name: "photo.jpg", isDirectory: false },
+      ],
     });
 
     expect(html).toContain('src="vault://local/attachments/demo.png"');
     expect(html).toContain('alt="attachments/demo.png"');
+    expect(html).toContain('src="vault://local/diagram.png"');
+    expect(html).toContain('alt="diagram.png"');
+    expect(html).toContain('style="max-width: 300px; width: 100%;"');
+    expect(html).toContain('src="vault://local/photo.jpg"');
+    expect(html).toContain('alt="Alt text"');
+    expect(html).not.toContain('alt="300"');
+    expect(html).toContain('<div class="embed-missing">missing.png</div>');
     expect(html).toContain('src="file:///Users/example/My%20Vault/regular.png"');
     expect(html).toContain('<div class="embed-missing">Missing Note</div>');
   });


### PR DESCRIPTION
Fixes #90

### What changed

* Added support for rendering wiki-style image embeds such as `![[image.png]]` in PDF exports.
* Image embeds are now resolved using the existing `resolveVaultImageSrc()` utility.
* Added `vault:` to the DOMPurify allowed URI protocols so `vault://` image sources are preserved.
* Added image-path detection to distinguish image embeds from regular wiki note embeds.
* Kept the existing `toFileUri()` implementation for normal Markdown image handling.
* Preserved the existing behavior for non-image wiki embeds.

### Result

Vault images can now be correctly resolved by the Electron PDF renderer using the existing `vault://` protocol.

### Testing

* Verified the PDF export flow uses the Electron `vault://` protocol.
* Verified normal Markdown image handling remains unchanged.
* Verified wiki note embeds continue to use the existing behavior.
