### PR TITLE
fix: harden match_note_chunks against cross-user data leak (closes #62)

### DIFF
--- a/src/lib/userDatabase.ts
+++ b/src/lib/userDatabase.ts
@@ -416,6 +416,8 @@ $$;
 REVOKE EXECUTE ON FUNCTION public.vote_on_space(uuid, smallint) FROM anon;
 
 -- Vector search functions
+-- SECURITY DEFINER: requires auth.uid(), rejects unscoped queries, verifies
+-- the caller has access to the requested space.  See issue #62.
 CREATE OR REPLACE FUNCTION public.match_note_chunks(
   query_embedding vector(1536),
   match_threshold float,
@@ -425,13 +427,25 @@ CREATE OR REPLACE FUNCTION public.match_note_chunks(
 RETURNS TABLE (id uuid, note_id uuid, content text, similarity float)
 LANGUAGE plpgsql SECURITY DEFINER SET search_path = public AS $$
 BEGIN
+  IF auth.uid() IS NULL THEN
+    RAISE EXCEPTION 'Authentication required';
+  END IF;
+
+  IF filter_space_id IS NULL THEN
+    RAISE EXCEPTION 'filter_space_id is required';
+  END IF;
+
+  IF NOT public.is_space_member(filter_space_id) THEN
+    RAISE EXCEPTION 'Access denied to space %', filter_space_id;
+  END IF;
+
   RETURN QUERY
   SELECT nc.id, nc.note_id, nc.content,
     1 - (nc.embedding <=> query_embedding) AS similarity
   FROM public.note_chunks nc
   JOIN public.notes n ON n.id = nc.note_id
   WHERE nc.embedding IS NOT NULL
-    AND (filter_space_id IS NULL OR n.space_id = filter_space_id)
+    AND n.space_id = filter_space_id
     AND 1 - (nc.embedding <=> query_embedding) > match_threshold
   ORDER BY nc.embedding <=> query_embedding
   LIMIT match_count;
@@ -446,6 +460,10 @@ CREATE OR REPLACE FUNCTION public.match_spaces(
 RETURNS TABLE (space_id uuid, title text, description text, similarity float)
 LANGUAGE plpgsql SECURITY DEFINER SET search_path = public AS $$
 BEGIN
+  IF auth.uid() IS NULL THEN
+    RAISE EXCEPTION 'Authentication required';
+  END IF;
+
   RETURN QUERY
   SELECT se.space_id, s.title, s.description,
     1 - (se.embedding <=> query_embedding) AS similarity

--- a/src/lib/vector.ts
+++ b/src/lib/vector.ts
@@ -156,7 +156,7 @@ export async function indexNote(noteId: string, content: string) {
 /**
  * Vector search query for notes (cosine similarity via DB function)
  */
-export async function searchNotes(query: string, spaceId?: string, topK = 5) {
+export async function searchNotes(query: string, spaceId: string, topK = 5) {
   const queryEmbedding = await generateEmbedding(query);
 
   const { data, error } = await supabase.rpc('match_note_chunks', {
@@ -177,7 +177,7 @@ export async function searchNotes(query: string, spaceId?: string, topK = 5) {
  */
 export async function askQuestionAboutNotes(
   query: string,
-  spaceId?: string,
+  spaceId: string,
   topK = 5
 ): Promise<{ answer: string; sources: any[]; chunkCount: number }> {
   // 1. Retrieve relevant chunks

--- a/supabase/schema.sql
+++ b/supabase/schema.sql
@@ -584,6 +584,8 @@ $$;
 REVOKE EXECUTE ON FUNCTION public.vote_on_space(uuid, smallint) FROM anon;
 
 -- Vector search: match note chunks by embedding similarity
+-- SECURITY DEFINER: requires auth.uid(), rejects unscoped queries, verifies
+-- the caller has access to the requested space.  See issue #62.
 CREATE OR REPLACE FUNCTION public.match_note_chunks(
   query_embedding vector(384),
   match_threshold float,
@@ -593,6 +595,18 @@ CREATE OR REPLACE FUNCTION public.match_note_chunks(
 RETURNS TABLE (id uuid, note_id uuid, note_title text, content text, similarity float)
 LANGUAGE plpgsql SECURITY DEFINER SET search_path = public AS $$
 BEGIN
+  IF auth.uid() IS NULL THEN
+    RAISE EXCEPTION 'Authentication required';
+  END IF;
+
+  IF filter_space_id IS NULL THEN
+    RAISE EXCEPTION 'filter_space_id is required';
+  END IF;
+
+  IF NOT public.is_space_member(filter_space_id) THEN
+    RAISE EXCEPTION 'Access denied to space %', filter_space_id;
+  END IF;
+
   RETURN QUERY
   SELECT nc.id, nc.note_id, n.title, nc.content,
     1 - (nc.embedding <=> query_embedding) AS similarity
@@ -600,7 +614,7 @@ BEGIN
   JOIN public.notes n ON n.id = nc.note_id
   WHERE nc.embedding IS NOT NULL
     AND n.deleted = false
-    AND (filter_space_id IS NULL OR n.space_id = filter_space_id)
+    AND n.space_id = filter_space_id
     AND 1 - (nc.embedding <=> query_embedding) > match_threshold
   ORDER BY nc.embedding <=> query_embedding
   LIMIT match_count;
@@ -608,6 +622,7 @@ END;
 $$;
 
 -- Vector search: match spaces by embedding similarity
+-- SECURITY DEFINER: requires auth.uid() to prevent unauthenticated abuse.
 CREATE OR REPLACE FUNCTION public.match_spaces(
   query_embedding vector(384),
   match_threshold float,
@@ -616,6 +631,10 @@ CREATE OR REPLACE FUNCTION public.match_spaces(
 RETURNS TABLE (space_id uuid, title text, description text, similarity float)
 LANGUAGE plpgsql SECURITY DEFINER SET search_path = public AS $$
 BEGIN
+  IF auth.uid() IS NULL THEN
+    RAISE EXCEPTION 'Authentication required';
+  END IF;
+
   RETURN QUERY
   SELECT se.space_id, s.title, s.description,
     1 - (se.embedding <=> query_embedding) AS similarity


### PR DESCRIPTION
## Summary

`match_note_chunks` runs as `SECURITY DEFINER`, which bypasses Row Level Security. The function had three critical gaps that allowed any authenticated user (or anonymous caller) to read note content from any private space:

1. **No `auth.uid()` guard** — the function could be called by `anon` role
2. **`filter_space_id DEFAULT NULL`** — unscoped queries scanned all spaces
3. **`OR filter_space_id IS NULL`** in the WHERE clause — when NULL was passed, the space filter was completely skipped

## What changed

**`supabase/schema.sql`** and **`src/lib/userDatabase.ts`** (embedded copy):
- Added `auth.uid() IS NULL` check — rejects unauthenticated callers
- Added `filter_space_id IS NULL` check — rejects unscoped queries
- Added `is_space_member(filter_space_id)` check — verifies caller owns/is-member of the requested space
- Removed the `(filter_space_id IS NULL OR n.space_id = filter_space_id)` branch from WHERE clause — now always enforces space scoping
- Applied the same `auth.uid()` guard to `match_spaces`

**`src/lib/vector.ts`**:
- Made `spaceId` required in `searchNotes()` to match the new server-side requirement (was `string?`)

## Testing

- Existing pgTAP tests (PR #92) cover the RLS policies — the new guards are orthogonal to RLS
- Manual test: call `match_note_chunks` with `filter_space_id = NULL` → should raise exception
- Manual test: call `match_note_chunks` with another user's `space_id` → should raise `is_space_member` exception
- Manual test: call `match_note_chunks` with your own `space_id` → should return results as before

Closes #62