### PR TITLE
fix: improve command palette search and platform shortcut label

### DIFF
--- a/src/components/modals/CommandPalette.tsx
+++ b/src/components/modals/CommandPalette.tsx
@@ -7,7 +7,7 @@
 
 import React, { useState, useEffect, useRef, useMemo } from "react";
 import { Command } from "../../types";
-import { filterCommands } from "../../utils/commandFilter";
+import { filterCommands, getPrimaryModifierLabel } from "../../utils/commandFilter";
 
 interface CommandPaletteProps {
   commands: Command[];
@@ -26,6 +26,9 @@ export function CommandPalette({ commands, onClose }: CommandPaletteProps) {
   const filteredCommands = useMemo(
     () => filterCommands(commands, query),
     [query, commands],
+  );
+  const modifierLabel = getPrimaryModifierLabel(
+    typeof navigator === "undefined" ? "" : navigator.platform,
   );
 
   const handleKeyDown = (e: React.KeyboardEvent) => {
@@ -48,9 +51,14 @@ export function CommandPalette({ commands, onClose }: CommandPaletteProps) {
 
   return (
     <div className="fixed inset-0 bg-black/50 flex items-start justify-center pt-[15vh] z-[9999]" onClick={onClose}>
-      <div className="w-full max-w-[520px] bg-(--bg-primary) border border-(--border-medium) rounded-xl shadow-none overflow-hidden" onClick={(e) => e.stopPropagation()}>
+      <div
+        role="dialog"
+        aria-label="Command palette"
+        className="w-full max-w-[520px] bg-(--bg-primary) border border-(--border-medium) rounded-xl shadow-none overflow-hidden"
+        onClick={(e) => e.stopPropagation()}
+      >
         <div className="flex items-center gap-3 px-4 py-3 border-b border-(--border-subtle)">
-          <span className="text-(--text-muted) text-lg shrink-0">{'\u2318'}</span>
+          <span className="text-(--text-muted) text-lg shrink-0">{modifierLabel}</span>
           <input
             ref={inputRef}
             className="flex-1 bg-transparent border-none outline-none text-(--text-primary) text-base placeholder:text-(--text-muted)"

--- a/src/components/modals/CommandPalette.tsx
+++ b/src/components/modals/CommandPalette.tsx
@@ -54,8 +54,10 @@ export function CommandPalette({ commands, onClose }: CommandPaletteProps) {
       <div
         role="dialog"
         aria-label="Command palette"
+        aria-modal="true"
         className="w-full max-w-[520px] bg-(--bg-primary) border border-(--border-medium) rounded-xl shadow-none overflow-hidden"
         onClick={(e) => e.stopPropagation()}
+        onKeyDown={handleKeyDown}
       >
         <div className="flex items-center gap-3 px-4 py-3 border-b border-(--border-subtle)">
           <span className="text-(--text-muted) text-lg shrink-0">{modifierLabel}</span>
@@ -69,7 +71,6 @@ export function CommandPalette({ commands, onClose }: CommandPaletteProps) {
               setQuery(e.target.value);
               setSelectedIndex(0);
             }}
-            onKeyDown={handleKeyDown}
           />
         </div>
 

--- a/src/utils/commandFilter.ts
+++ b/src/utils/commandFilter.ts
@@ -1,17 +1,12 @@
 export interface FilterableCommand {
+  id?: string;
   label: string;
   category?: string;
 }
 
-/** Substring filter used by the command palette. */
+/** Word-aware filter used by the command palette. */
 export function filterCommands<T extends FilterableCommand>(commands: T[], query: string): T[] {
-  if (!query.trim()) return commands;
-  const q = query.toLowerCase();
-  return commands.filter(
-    (cmd) =>
-      cmd.label.toLowerCase().includes(q) ||
-      (cmd.category && cmd.category.toLowerCase().includes(q)),
-  );
+  return filterCommandsByWords(commands, query);
 }
 
 /** Word-aware filter: every word must appear in the label or category. */
@@ -19,7 +14,12 @@ export function filterCommandsByWords<T extends FilterableCommand>(commands: T[]
   const words = query.toLowerCase().split(/\s+/).filter(Boolean);
   if (words.length === 0) return commands;
   return commands.filter((cmd) => {
-    const haystack = `${cmd.label} ${cmd.category || ""}`.toLowerCase();
+    const haystack = `${cmd.id || ""} ${cmd.label} ${cmd.category || ""}`.toLowerCase();
     return words.every((word) => haystack.includes(word));
   });
+}
+
+/** Primary keyboard modifier label for the current platform. */
+export function getPrimaryModifierLabel(platform: string): "⌘" | "Ctrl" {
+  return platform.toLowerCase().includes("mac") ? "⌘" : "Ctrl";
 }

--- a/src/utils/commandFilter.ts
+++ b/src/utils/commandFilter.ts
@@ -9,7 +9,7 @@ export function filterCommands<T extends FilterableCommand>(commands: T[], query
   return filterCommandsByWords(commands, query);
 }
 
-/** Word-aware filter: every word must appear in the label or category. */
+/** Word-aware filter: every word must appear in the id, label, or category. */
 export function filterCommandsByWords<T extends FilterableCommand>(commands: T[], query: string): T[] {
   const words = query.toLowerCase().split(/\s+/).filter(Boolean);
   if (words.length === 0) return commands;

--- a/tests/command-filter.test.ts
+++ b/tests/command-filter.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from "vitest";
-import { filterCommands, filterCommandsByWords } from "../src/utils/commandFilter";
+import {
+  filterCommands,
+  filterCommandsByWords,
+  getPrimaryModifierLabel,
+} from "../src/utils/commandFilter";
 
 const commands = [
   { id: "new", label: "Create note", category: "File" },
@@ -17,11 +21,23 @@ describe("command filter", () => {
     expect(filterCommands(commands, "view").map((c) => c.id)).toEqual(["sidebar", "graph"]);
   });
 
-  it("current substring filter misses word-reordered queries", () => {
-    expect(filterCommands(commands, "new note")).toEqual([]);
+  it("matches all query words across command metadata", () => {
+    expect(filterCommands(commands, "new note").map((c) => c.id)).toEqual(["new"]);
+    expect(filterCommands(commands, "view graph").map((c) => c.id)).toEqual(["graph"]);
   });
 
   it("word filter finds Create note when every word appears", () => {
     expect(filterCommandsByWords(commands, "create note").map((c) => c.id)).toEqual(["new"]);
+  });
+});
+
+describe("primary modifier label", () => {
+  it("uses the Command symbol on macOS", () => {
+    expect(getPrimaryModifierLabel("MacIntel")).toBe("⌘");
+  });
+
+  it("uses Ctrl on Windows and Linux", () => {
+    expect(getPrimaryModifierLabel("Win32")).toBe("Ctrl");
+    expect(getPrimaryModifierLabel("Linux x86_64")).toBe("Ctrl");
   });
 });


### PR DESCRIPTION
## What changed

- Show `⌘` on macOS and `Ctrl` on Windows/Linux in the command palette.
- Match command queries across command IDs, labels, and categories.
- Add dialog semantics to the command palette.
- Add regression coverage for word-based search and platform modifier labels.

## Why

The command palette always displayed the macOS modifier and could not find
`Create note` when searching for `new note`.

## Verification

- `npm exec vitest run tests/command-filter.test.ts`
- `npm run lint`

Closes #86
