### PR TITLE
Fix/statusbar clickable breadcrumbs

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -430,6 +430,7 @@ export default function App() {
   const [graphFullScreen, setGraphFullScreen] = useState(false);
   const [showSearch, setShowSearch] = useState(false);
   const [showBookmarks, setShowBookmarks] = useState(false);
+  const [folderRevealRequest, setFolderRevealRequest] = useState<{ path: string; nonce: number } | null>(null);
   const [bookmarkStore, setBookmarkStore] = useState<{
     vaultPath: string | null;
     items: BookmarkEntry[];
@@ -4152,6 +4153,20 @@ export default function App() {
     setNoteContentCache,
   });
 
+  const handleRevealFolderInNavigation = useCallback((path: string) => {
+    setShowSidebar(true);
+    setShowSearch(false);
+    setShowBookmarks(false);
+    ooAppRef.current?.workspace?.revealDefaultView?.("left");
+    setFolderRevealRequest((previous) => ({
+      path,
+      nonce: (previous?.nonce ?? 0) + 1,
+    }));
+  }, []);
+  const handleRevealFolderHandled = useCallback(() => {
+    setFolderRevealRequest(null);
+  }, []);
+
   // ── Commands (for Command Palette) ──────────────────
   const commands = useAppCommands({
     handleNewNote,
@@ -5118,6 +5133,8 @@ export default function App() {
                   onToggleGroupAutoSave={handleToggleGroupAutoSave}
                   onAddFileToGroup={handleAddFileToGroup}
                   hasWallpaper={Boolean(settings.backgroundImage)}
+                  revealFolderRequest={folderRevealRequest}
+                  onRevealFolderHandled={handleRevealFolderHandled}
                 />
               )}
             </div>
@@ -5430,6 +5447,7 @@ export default function App() {
           showEditingMode={settings.showEditingModeStatusBar !== false}
           backlinkCount={backlinks.length}
           syncStatus={syncStatus}
+          onRevealFolder={handleRevealFolderInNavigation}
         />
       )}
     </div>

--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -76,6 +76,8 @@ interface SidebarProps {
   onDuplicateGroup?: (id: string) => void;
   onToggleGroupAutoSave?: (id: string) => void;
   hasWallpaper?: boolean;
+  revealFolderRequest?: { path: string; nonce: number } | null;
+  onRevealFolderHandled?: () => void;
 }
 
 type SortMode =
@@ -399,6 +401,8 @@ export function Sidebar({
   onToggleGroupAutoSave = () => {},
   onAddFileToGroup = () => {},
   hasWallpaper = false,
+  revealFolderRequest = null,
+  onRevealFolderHandled,
 }: SidebarProps) {
   const [expandedDirs, setExpandedDirs] = useState<Set<string>>(new Set());
   const [selectedFolder, setSelectedFolder] = useState<string | null>("");
@@ -566,6 +570,55 @@ export function Sidebar({
       return changed ? next : previous;
     });
   }, [activeFilePath, starredNotes]);
+
+  useEffect(() => {
+    if (!revealFolderRequest) return;
+    const targetPath = revealFolderRequest.path;
+    const maxRevealAttempts = 20;
+    let frame = 0;
+    let attempts = 0;
+
+    setFilterQuery("");
+    setSelectedFolder(targetPath);
+    setIsFoldersCollapsed(false);
+
+    setExpandedDirs((previous) => {
+      const next = new Set(previous);
+      let currentPath = "";
+      let changed = false;
+
+      for (const part of targetPath.split("/").filter(Boolean)) {
+        currentPath = currentPath ? `${currentPath}/${part}` : part;
+        if (!next.has(currentPath)) {
+          next.add(currentPath);
+          changed = true;
+        }
+      }
+
+      return changed ? next : previous;
+    });
+
+    const revealTarget = () => {
+      const folderItems = document.querySelectorAll<HTMLElement>("[data-sidebar-folder-path]");
+      const target = Array.from(folderItems).find(
+        (element) => element.dataset.sidebarFolderPath === targetPath,
+      );
+      if (target) {
+        target.scrollIntoView({ block: "nearest" });
+        onRevealFolderHandled?.();
+        return;
+      }
+
+      attempts += 1;
+      if (attempts < maxRevealAttempts) {
+        frame = window.requestAnimationFrame(revealTarget);
+      }
+    };
+
+    frame = window.requestAnimationFrame(revealTarget);
+
+    return () => window.cancelAnimationFrame(frame);
+  }, [onRevealFolderHandled, revealFolderRequest]);
 
   const toggleDir = (path: string) => {
     setExpandedDirs((prev) => {
@@ -918,6 +971,7 @@ export function Sidebar({
       return (
         <React.Fragment key={entry.path}>
           <button
+            data-sidebar-folder-path={entry.path}
             className={cx(
               "nn-folder-item",
               isSelected && "active",
@@ -1216,6 +1270,7 @@ export function Sidebar({
                 >
                   {/* Special / virtual views */}
                   <button
+                    data-sidebar-folder-path=""
                     className={cx(
                       "nn-folder-item",
                       selectedFolder === "" && "active",

--- a/src/components/layout/StatusBar.tsx
+++ b/src/components/layout/StatusBar.tsx
@@ -17,6 +17,7 @@ import {
 } from "lucide-react";
 import { Tab, Theme, ViewMode, FileEntry } from "../../types";
 import { countWords, countCharacters } from "../../utils/helpers";
+import { getAPI } from "../../utils/api";
 import type { PluginStatusBarItem } from '../../types/plugin';
 import { VimModeIndicator } from "./VimModeIndicator";
 
@@ -27,6 +28,10 @@ const statusItemClass =
   "inline-flex h-[26px] shrink-0 items-center gap-1.5 whitespace-nowrap px-1.5 text-[12px] leading-none text-[var(--status-bar-text-color)]";
 const crumbClass =
   "inline-flex max-w-[160px] items-center gap-1 overflow-hidden text-ellipsis whitespace-nowrap text-[12px] text-[var(--text-secondary)]";
+const crumbFocusClass =
+  "focus-visible:outline focus-visible:outline-1 focus-visible:outline-offset-1 focus-visible:outline-[var(--accent-primary)]";
+const crumbButtonClass =
+  `${crumbClass} ${crumbFocusClass} h-[22px] cursor-pointer rounded-[4px] border-0 bg-transparent px-1 transition-colors hover:bg-[var(--bg-hover)] hover:text-[var(--text-primary)]`;
 const crumbSepClass = "mx-0.5 text-[var(--text-faint)] opacity-70";
 
 interface StatusBarProps {
@@ -41,6 +46,7 @@ interface StatusBarProps {
   showEditingMode?: boolean;
   backlinkCount?: number;
   syncStatus?: SyncStatus | null;
+  onRevealFolder?: (path: string) => void;
 }
 
 export function StatusBar({
@@ -53,34 +59,72 @@ export function StatusBar({
   showEditingMode = true,
   backlinkCount = 0,
   syncStatus = null,
+  onRevealFolder,
 }: StatusBarProps) {
   const wordCount = content ? countWords(content) : 0;
   const charCount = content ? countCharacters(content) : 0;
+  const isRealFileTab = Boolean(activeTab && !activeTab.path.startsWith("__"));
 
   const pathParts =
-    activeTab && !activeTab.path.startsWith("__")
+    activeTab && isRealFileTab
       ? activeTab.path.split("/").filter(Boolean)
       : [];
   const noteName =
     pathParts.length > 0
       ? pathParts[pathParts.length - 1].replace(/\.md$/, "").replace(/\.canvas$/, "")
       : activeTab?.name || "";
+  const canNavigateBreadcrumbs = Boolean(onRevealFolder && isRealFileTab && pathParts.length > 0);
+  const canCopyActivePath = Boolean(activeTab?.path && isRealFileTab);
+  const copyActivePath = () => {
+    if (!canCopyActivePath || !activeTab?.path) return;
+    void getAPI().writeClipboardText(activeTab.path);
+  };
 
   return (
     <div className={statusBarClass}>
       <div className={statusGroupClass} aria-label="Breadcrumbs">
-        <span className={statusItemClass} title="Root">
+        <button
+          type="button"
+          className={`${statusItemClass} ${crumbFocusClass} cursor-pointer rounded-[4px] border-0 bg-transparent hover:bg-[var(--bg-hover)] hover:text-[var(--text-primary)]`}
+          title="Reveal root folder"
+          aria-label="Reveal root folder"
+          onClick={() => onRevealFolder?.("")}
+          disabled={!canNavigateBreadcrumbs}
+        >
           <Home size={13} strokeWidth={1.75} />
-        </span>
-        {pathParts.slice(0, -1).map((part, i) => (
-          <React.Fragment key={`${part}-${i}`}>
+        </button>
+        {pathParts.slice(0, -1).map((part, i) => {
+          const folderPath = pathParts.slice(0, i + 1).join("/");
+          return (
+            <React.Fragment key={folderPath}>
+              <span className={crumbSepClass}>›</span>
+              <button
+                type="button"
+                className={crumbButtonClass}
+                title={`Reveal ${folderPath}`}
+                aria-label={`Reveal ${folderPath}`}
+                onClick={() => onRevealFolder?.(folderPath)}
+              >
+                {part}
+              </button>
+            </React.Fragment>
+          );
+        })}
+        {noteName && canCopyActivePath && (
+          <>
             <span className={crumbSepClass}>›</span>
-            <span className={crumbClass} title={part}>
-              {part}
-            </span>
-          </React.Fragment>
-        ))}
-        {noteName && (
+            <button
+              type="button"
+              className={`${crumbButtonClass} font-medium text-[var(--text-primary)]`}
+              title="Copy note path"
+              aria-label="Copy note path"
+              onClick={copyActivePath}
+            >
+              {noteName}
+            </button>
+          </>
+        )}
+        {noteName && !canCopyActivePath && (
           <>
             <span className={crumbSepClass}>›</span>
             <span className={`${crumbClass} font-medium text-[var(--text-primary)]`}>


### PR DESCRIPTION
Fixes #89

- Converts status bar breadcrumbs to clickable buttons
- Reveals clicked folders in the sidebar file explorer
- Reveals root from the home breadcrumb
- Copies the active note path from the final breadcrumb
- Expands parent folders and scrolls the revealed folder into view