### PR TITLE
fix(vim): allow space key in Vim insert mode inside editor (#88)

### DIFF
--- a/src/keybindings/globalKeys.ts
+++ b/src/keybindings/globalKeys.ts
@@ -15,6 +15,7 @@ let initialized = false;
 let enabled = true;
 let leaderPending = false;
 let leaderTimer: number | null = null;
+let currentVimMode = "normal";
 
 const LEADER_EVENT_MAP: Record<LeaderKey, string> = {
   f: "oo:fuzzy-search",
@@ -27,6 +28,21 @@ const LEADER_EVENT_MAP: Record<LeaderKey, string> = {
   "/": "oo:global-search",
   p: "oo:command-palette",
 };
+
+export function setVimMode(mode: string): void {
+  currentVimMode = mode ? mode.toLowerCase() : "normal";
+}
+
+export function getVimMode(): string {
+  return currentVimMode;
+}
+
+function handleVimModeChange(event: Event): void {
+  const customEvent = event as CustomEvent<{ mode?: string }>;
+  if (customEvent.detail?.mode) {
+    setVimMode(customEvent.detail.mode);
+  }
+}
 
 function clearLeaderState(): void {
   leaderPending = false;
@@ -83,6 +99,12 @@ function onGlobalKeydown(event: KeyboardEvent): void {
     !event.ctrlKey &&
     !event.metaKey
   ) {
+    const target = event.target as Element | null;
+    const withinCodeMirror = !!(target as HTMLElement | null)?.closest(".cm-editor");
+    if (withinCodeMirror && currentVimMode === "insert") {
+      return;
+    }
+
     event.preventDefault();
     leaderPending = true;
     if (leaderTimer !== null) {
@@ -115,6 +137,7 @@ export function initGlobalKeybindings(): void {
   if (initialized) return;
 
   window.addEventListener("keydown", onGlobalKeydown);
+  window.addEventListener("oo:vim-mode-change", handleVimModeChange);
   initialized = true;
 }
 
@@ -122,5 +145,6 @@ export function setGlobalKeybindingsEnabled(nextEnabled: boolean): void {
   enabled = nextEnabled;
   if (!enabled) {
     clearLeaderState();
+    setVimMode("normal");
   }
 }

--- a/tests/global-keys.test.ts
+++ b/tests/global-keys.test.ts
@@ -1,14 +1,25 @@
 // @vitest-environment jsdom
-import { describe, expect, it } from "vitest";
-import { shouldHandleEvent } from "../src/keybindings/globalKeys";
+import { describe, expect, it, beforeEach } from "vitest";
+import {
+  shouldHandleEvent,
+  initGlobalKeybindings,
+  setGlobalKeybindingsEnabled,
+  setVimMode,
+} from "../src/keybindings/globalKeys";
 
 function keyEvent(target: Element): KeyboardEvent {
-  const event = new KeyboardEvent("keydown", { key: " ", bubbles: true });
+  const event = new KeyboardEvent("keydown", { key: " ", bubbles: true, cancelable: true });
   Object.defineProperty(event, "target", { value: target });
   return event;
 }
 
 describe("global key handling", () => {
+  beforeEach(() => {
+    initGlobalKeybindings();
+    setGlobalKeybindingsEnabled(true);
+    setVimMode("normal");
+  });
+
   it("ignores events with no target", () => {
     const event = new KeyboardEvent("keydown", { key: " " });
     expect(shouldHandleEvent(event)).toBe(false);
@@ -22,14 +33,32 @@ describe("global key handling", () => {
     expect(shouldHandleEvent(keyEvent(textarea))).toBe(false);
   });
 
-  it("currently handles Space inside CodeMirror, including insert mode", () => {
+  it("handles Space inside CodeMirror in normal mode", () => {
     const wrap = document.createElement("div");
     wrap.className = "cm-editor";
     const content = document.createElement("div");
     content.className = "cm-content";
     wrap.append(content);
     document.body.append(wrap);
-    expect(shouldHandleEvent(keyEvent(content))).toBe(true);
+
+    setVimMode("normal");
+    const event = keyEvent(content);
+    window.dispatchEvent(event);
+    expect(event.defaultPrevented).toBe(true);
+  });
+
+  it("allows Space inside CodeMirror in insert mode without preventing default", () => {
+    const wrap = document.createElement("div");
+    wrap.className = "cm-editor";
+    const content = document.createElement("div");
+    content.className = "cm-content";
+    wrap.append(content);
+    document.body.append(wrap);
+
+    setVimMode("insert");
+    const event = keyEvent(content);
+    window.dispatchEvent(event);
+    expect(event.defaultPrevented).toBe(false);
   });
 
   it("handles keys on the document chrome", () => {


### PR DESCRIPTION
## Description
Fixes #88
Prevents `globalKeys.ts` from intercepting the `Space` key as a leader key while the user is typing in Vim **Insert mode** inside CodeMirror.
### Changes:
- Listens to `oo:vim-mode-change` events in `src/keybindings/globalKeys.ts` to maintain current Vim mode state.
- Bypasses `Space` leader interception when keypress occurs inside `.cm-editor` and Vim mode is in `insert`.
- Added unit tests in `tests/global-keys.test.ts` verifying `Space` key behavior in Insert vs Normal mode.
## Verification
- [x] `npx vitest run tests/global-keys.test.ts` passed 5/5 tests.
- [x] `npm run lint` passed with 0 TypeScript compilation errors.