### PR TITLE
fix: open plugin web links through validated external IPC

### DIFF
--- a/electron/externalUrl.ts
+++ b/electron/externalUrl.ts
@@ -1,0 +1,17 @@
+const ALLOWED_EXTERNAL_PROTOCOLS = new Set(["http:", "https:", "mailto:"]);
+
+/** Validate and normalize a URL before handing it to the operating system. */
+export function allowedExternalUrl(value: string): string {
+  let url: URL;
+  try {
+    url = new URL(value);
+  } catch {
+    throw new Error("External URLs must be absolute HTTP, HTTPS, or mailto URLs.");
+  }
+
+  if (!ALLOWED_EXTERNAL_PROTOCOLS.has(url.protocol)) {
+    throw new Error(`External URL protocol is not allowed: ${url.protocol}`);
+  }
+
+  return url.href;
+}

--- a/electron/ipc.ts
+++ b/electron/ipc.ts
@@ -10,6 +10,7 @@ import * as fs from 'fs/promises';
 import * as nodePath from 'path';
 import { FileSystemManager } from './fileSystem.js';
 import { SearchEngine } from './search.js';
+import { allowedExternalUrl } from './externalUrl.js';
 
 export function registerIpcHandlers(
   ipcMain: IpcMain,
@@ -65,6 +66,9 @@ export function registerIpcHandlers(
   });
 
   ipcMain.handle('desktop:openPath', async (_event, targetPath: string) => shell.openPath(targetPath));
+  ipcMain.handle('desktop:openExternal', async (_event, url: string) => {
+    await shell.openExternal(allowedExternalUrl(url));
+  });
   ipcMain.handle('desktop:showItemInFolder', (_event, targetPath: string) => shell.showItemInFolder(targetPath));
   ipcMain.handle('desktop:getPath', (_event, name: Parameters<typeof app.getPath>[0]) => app.getPath(name));
 

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -34,6 +34,9 @@ const electronAPI = {
   openPath: (targetPath: string): Promise<string> =>
     ipcRenderer.invoke('desktop:openPath', targetPath),
 
+  openExternal: (url: string): Promise<void> =>
+    ipcRenderer.invoke('desktop:openExternal', url),
+
   showItemInFolder: (targetPath: string): Promise<void> =>
     ipcRenderer.invoke('desktop:showItemInFolder', targetPath),
 

--- a/src/lib/pluginManager.ts
+++ b/src/lib/pluginManager.ts
@@ -162,7 +162,7 @@ export class PluginManager {
       ...(electron.shell || {}),
       openPath: (targetPath: string) => bridge.openPath?.(targetPath) ?? Promise.resolve(''),
       showItemInFolder: (targetPath: string) => bridge.showItemInFolder?.(targetPath),
-      openExternal: (url: string) => bridge.openPath?.(url) ?? Promise.resolve(''),
+      openExternal: (url: string) => bridge.openExternal?.(url) ?? Promise.resolve(),
     };
     // Some established plugins access Electron through window.electron rather
     // than require('electron'). Modern Electron no longer exposes `remote` in
@@ -436,7 +436,7 @@ export class PluginManager {
           ...(electron.shell || {}),
           openPath: (targetPath: string) => bridge.openPath?.(targetPath) ?? Promise.resolve(''),
           showItemInFolder: (targetPath: string) => bridge.showItemInFolder?.(targetPath),
-          openExternal: (url: string) => bridge.openPath?.(url) ?? Promise.resolve(''),
+          openExternal: (url: string) => bridge.openExternal?.(url) ?? Promise.resolve(),
         };
         return {
           ...electron,

--- a/src/utils/mockAPI.ts
+++ b/src/utils/mockAPI.ts
@@ -263,6 +263,7 @@ export function createMockAPI(): ElectronAPI {
     showOpenDialog: async () => ({ canceled: true, filePaths: [] }),
     showSaveDialog: async () => ({ canceled: true, filePath: "" }),
     openPath: async () => "",
+    openExternal: async () => {},
     showItemInFolder: async () => {},
     renamePath: async (_oldPath: string, newPath: string) => {
       mockVaultPath = newPath;

--- a/tests/external-url.test.ts
+++ b/tests/external-url.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from "vitest";
+import { allowedExternalUrl } from "../electron/externalUrl";
+
+describe("external URL policy", () => {
+  it.each([
+    "https://example.com/docs",
+    "http://localhost:3000/help",
+    "mailto:support@example.com",
+  ])("allows %s", (url) => {
+    expect(allowedExternalUrl(url)).toBe(url);
+  });
+
+  it.each([
+    "file:///tmp/private.txt",
+    "vault://local/Note.md",
+    "javascript:alert(1)",
+    "/tmp/private.txt",
+    String.raw`C:\\Users\\me\\private.txt`,
+  ])("rejects %s", (url) => {
+    expect(() => allowedExternalUrl(url)).toThrow();
+  });
+});

--- a/tests/ipc-external.test.ts
+++ b/tests/ipc-external.test.ts
@@ -1,0 +1,65 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const electronMocks = vi.hoisted(() => ({
+  openExternal: vi.fn(async () => {}),
+}));
+
+vi.mock("electron", () => ({
+  app: { getPath: vi.fn() },
+  BrowserWindow: class {},
+  clipboard: { readText: vi.fn(), writeText: vi.fn() },
+  dialog: { showOpenDialog: vi.fn(), showSaveDialog: vi.fn() },
+  shell: {
+    openExternal: electronMocks.openExternal,
+    openPath: vi.fn(),
+    showItemInFolder: vi.fn(),
+    trashItem: vi.fn(),
+  },
+}));
+
+import { registerIpcHandlers } from "../electron/ipc";
+
+type Handler = (...args: any[]) => any;
+
+function registeredHandlers(): Map<string, Handler> {
+  const handlers = new Map<string, Handler>();
+  const ipcMain = {
+    handle: vi.fn((channel: string, handler: Handler) => {
+      handlers.set(channel, handler);
+    }),
+    on: vi.fn(),
+  };
+
+  registerIpcHandlers(
+    ipcMain as any,
+    {} as any,
+    {} as any,
+    () => null,
+  );
+  return handlers;
+}
+
+describe("desktop:openExternal IPC", () => {
+  beforeEach(() => {
+    electronMocks.openExternal.mockClear();
+  });
+
+  it("opens validated web URLs with the external shell", async () => {
+    const handler = registeredHandlers().get("desktop:openExternal");
+
+    await handler?.({}, "https://example.com/docs");
+
+    expect(electronMocks.openExternal).toHaveBeenCalledWith(
+      "https://example.com/docs",
+    );
+  });
+
+  it("rejects local paths before invoking the external shell", async () => {
+    const handler = registeredHandlers().get("desktop:openExternal");
+
+    await expect(handler?.({}, "file:///tmp/private.txt")).rejects.toThrow(
+      "protocol is not allowed",
+    );
+    expect(electronMocks.openExternal).not.toHaveBeenCalled();
+  });
+});

--- a/tests/plugin-runtime.test.ts
+++ b/tests/plugin-runtime.test.ts
@@ -54,6 +54,7 @@ beforeEach(() => {
     deleteDirectory: vi.fn(async () => {}),
     renameFile: vi.fn(async () => {}),
     openPath: vi.fn(async () => ''),
+    openExternal: vi.fn(async () => {}),
     showItemInFolder: vi.fn(async () => {}),
     writeClipboardText: vi.fn(async () => {}),
     readClipboardText: vi.fn(async () => ''),
@@ -134,6 +135,7 @@ body.theme-dark .plain-plugin-button { border-color: blue; }
     expect((window as any).electron.remote.getCurrentWindow().isMaximized()).toBe(false);
     expect((window as any).electron.remote.getCurrentWebContents().getZoomFactor()).toBe(1);
     expect((window as any).require('electron').shell.openPath).toBeTypeOf('function');
+    expect((window as any).require('electron').shell.openExternal).toBeTypeOf('function');
     expect((window as any).require('electron').shell.showItemInFolder).toBeTypeOf('function');
     expect((window as any).activeWindow).toBe(window);
     expect((window as any).activeDocument).toBe(document);
@@ -159,6 +161,14 @@ body.theme-dark .plain-plugin-button { border-color: blue; }
     const shell = (window as any).require('electron').shell;
     await shell.openPath('/vault/Folder/Note.md');
     expect((window as any).electronAPI.openPath).toHaveBeenCalledWith('/vault/Folder/Note.md');
+
+    await shell.openExternal('https://github.com/OpenOnyx/OpenOnyx');
+    expect((window as any).electronAPI.openExternal).toHaveBeenCalledWith(
+      'https://github.com/OpenOnyx/OpenOnyx',
+    );
+    expect((window as any).electronAPI.openPath).not.toHaveBeenCalledWith(
+      'https://github.com/OpenOnyx/OpenOnyx',
+    );
   });
 
   it('exposes Lezer LR parser APIs required by Excalidraw', () => {


### PR DESCRIPTION
## Summary

- add a dedicated `desktop:openExternal` preload/IPC path for plugin web links
- allow only `http:`, `https:`, and `mailto:` URLs before calling Electron's `shell.openExternal`
- route both plugin Electron shell shims through the new bridge
- add URL-policy, IPC-registration, and plugin-runtime regression coverage

## Why

Plugin `shell.openExternal()` currently delegates to `openPath()`, which is intended for local files. Web links therefore fail, while a local path passed through the external-link API is not rejected.

## Verification

- `./node_modules/.bin/vitest run --exclude tests/real-plugin-bundles.test.ts` (148 tests)
- `./node_modules/.bin/tsc --noEmit`
- `./node_modules/.bin/vite build`
- `./node_modules/.bin/tsc -p tsconfig.electron.json`

Closes #73