### PR TITLE
ci: split PR gate into typecheck, unit-tests, and build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,14 +6,18 @@ on:
     branches:
       - main
 
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
 
 jobs:
-  test:
-    name: Lint and tests
+  typecheck:
+    name: typecheck
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    timeout-minutes: 10
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -30,5 +34,42 @@ jobs:
       - name: Typecheck
         run: npm run lint
 
+  unit-tests:
+    name: unit-tests
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
       - name: Unit and integration tests
         run: npm test
+
+  build:
+    name: build
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Production build
+        run: npm run build


### PR DESCRIPTION
## Why

PRs currently show a single **Lint and tests** check. That job only runs `tsc --noEmit` and Vitest. A contributor can merge without ever compiling the Vite renderer or the Electron main process.

This is not covered by any open PR. #96 is community docs. #93 lists `ci.yml` only because of a stale merge-base; it does not change the workflow.

## What changed

`.github/workflows/ci.yml` now runs three parallel jobs on every pull request and every push to `main`:

| Check | Command |
| --- | --- |
| `typecheck` | `npm run lint` |
| `unit-tests` | `npm test` |
| `build` | `npm run build` |

In-progress runs for the same PR are cancelled when a new push arrives.

Verified locally: lint, 138 tests, and `npm run build` all passed.

## After merge (ruleset)

Do **not** add required status checks until this workflow is on `main`. Then add these three names to `main-rules`:

- `typecheck`
- `unit-tests`
- `build`

Until those names are required, CI is still advisory.

## Out of scope (on purpose)

- Nightly plugin/Pandoc jobs
- `electron-builder` on PRs
- Dependabot
- CONTRIBUTING / SECURITY (owned by #96)