### PR TITLE
security: harden renderer IPC, preview XSS, and default plugin grants

### DIFF
--- a/electron/fileSystem.ts
+++ b/electron/fileSystem.ts
@@ -9,7 +9,7 @@
 import * as fs from 'fs';
 import * as path from 'path';
 import * as crypto from 'crypto';
-import { resolveInsideRoot } from './pathSafety.js';
+import { resolveInsideRoot, sanitizeAttachmentFileName } from './pathSafety.js';
 
 export interface FileEntry {
   name: string;
@@ -136,7 +136,7 @@ export class FileSystemManager {
   }
 
   async readBinary(filePath: string): Promise<Uint8Array> {
-    const absolutePath = path.isAbsolute(filePath) ? filePath : this.resolvePath(filePath);
+    const absolutePath = this.resolvePath(filePath);
     return new Uint8Array(await fs.promises.readFile(absolutePath));
   }
 
@@ -419,19 +419,20 @@ export class FileSystemManager {
    */
   async saveImage(fileName: string, base64Data: string): Promise<string> {
     if (!this.vaultPath) throw new Error('No vault path set');
+    const safeName = sanitizeAttachmentFileName(fileName);
     
     // Create attachments folder if it doesn't exist
-    const attachmentsDir = path.join(this.vaultPath, 'attachments');
+    const attachmentsDir = resolveInsideRoot(this.vaultPath, 'attachments');
     if (!fs.existsSync(attachmentsDir)) {
       fs.mkdirSync(attachmentsDir, { recursive: true });
     }
     
     // Generate unique filename if needed
-    let uniqueName = fileName;
+    let uniqueName = safeName;
     let counter = 1;
-    while (fs.existsSync(path.join(attachmentsDir, uniqueName))) {
-      const ext = path.extname(fileName);
-      const base = path.basename(fileName, ext);
+    while (fs.existsSync(resolveInsideRoot(this.vaultPath, path.join('attachments', uniqueName)))) {
+      const ext = path.extname(safeName);
+      const base = path.basename(safeName, ext);
       uniqueName = `${base}-${counter}${ext}`;
       counter++;
     }
@@ -440,7 +441,7 @@ export class FileSystemManager {
     const base64Content = base64Data.replace(/^data:image\/\w+;base64,/, '');
     
     // Write the image file
-    const imagePath = path.join(attachmentsDir, uniqueName);
+    const imagePath = resolveInsideRoot(this.vaultPath, path.join('attachments', uniqueName));
     fs.writeFileSync(imagePath, Buffer.from(base64Content, 'base64'));
     
     // Return relative path for markdown
@@ -525,15 +526,16 @@ export class FileSystemManager {
   ): Promise<{ relativePath: string; isDuplicate: boolean }> {
     if (!this.vaultPath) throw new Error('No vault path set');
 
-    const attachmentsDir = path.join(this.vaultPath, 'attachments');
+    const attachmentsDir = resolveInsideRoot(this.vaultPath, 'attachments');
     if (!fs.existsSync(attachmentsDir)) {
       fs.mkdirSync(attachmentsDir, { recursive: true });
     }
 
+    const safeName = sanitizeAttachmentFileName(fileName || 'image.png');
     const base64Content = base64Data.replace(/^data:image\/\w+;base64,/, '');
     const buffer = Buffer.from(base64Content, 'base64');
     const hash = this.hashContent(buffer);
-    const ext = path.extname(fileName);
+    const ext = path.extname(safeName);
 
     // Check if a file with this hash already exists
     const mappingPath = path.join(this.ensureDataDir(), 'attachment-map.json');
@@ -551,7 +553,7 @@ export class FileSystemManager {
 
     // New file — store with hash name
     const hashName = `${hash}${ext}`;
-    const imagePath = path.join(attachmentsDir, hashName);
+    const imagePath = resolveInsideRoot(this.vaultPath, path.join('attachments', hashName));
     fs.writeFileSync(imagePath, buffer);
 
     // Update mapping

--- a/electron/ipc.ts
+++ b/electron/ipc.ts
@@ -10,6 +10,9 @@ import * as fs from 'fs/promises';
 import * as nodePath from 'path';
 import { FileSystemManager } from './fileSystem.js';
 import { SearchEngine } from './search.js';
+import { assertPublicHttpUrl } from './outboundUrl.js';
+import { isInsideRoot } from './pathSafety.js';
+import { approveVaultPath, isApprovedVaultPath, seedApprovedVaultPaths } from './vaultAccess.js';
 
 export function registerIpcHandlers(
   ipcMain: IpcMain,
@@ -20,9 +23,28 @@ export function registerIpcHandlers(
   getPreviousPaths?: () => string[],
   removePreviousPath?: (vaultPath: string) => string[],
 ): void {
+  seedApprovedVaultPaths([
+    fsManager.getVaultPath(),
+    ...(getPreviousPaths ? getPreviousPaths() : []),
+  ]);
+
+  const resolveInsideCurrentVault = (targetPath: string): string => {
+    const vaultPath = fsManager.getVaultPath();
+    if (!vaultPath) throw new Error('No vault path set');
+    const resolved = nodePath.isAbsolute(targetPath)
+      ? nodePath.resolve(targetPath)
+      : fsManager.getAbsolutePath(targetPath);
+    if (!isInsideRoot(vaultPath, resolved)) {
+      throw new Error('Path is outside the active vault');
+    }
+    return resolved;
+  };
 
   // ── Vault Operations ──────────────────────────────
   ipcMain.handle('vault:setPath', async (_event, vaultPath: string) => {
+    if (vaultPath && !isApprovedVaultPath(vaultPath)) {
+      throw new Error('Vault path must come from a folder dialog or a previously opened vault');
+    }
     const success = fsManager.setVaultPath(vaultPath);
     if (success) {
       if (onVaultPathChange) onVaultPathChange(vaultPath);
@@ -56,17 +78,41 @@ export function registerIpcHandlers(
 
   ipcMain.handle('desktop:showOpenDialog', async (_event, options: Electron.OpenDialogOptions) => {
     const owner = getMainWindow();
-    return owner ? dialog.showOpenDialog(owner, options) : dialog.showOpenDialog(options);
+    const result = owner ? await dialog.showOpenDialog(owner, options) : await dialog.showOpenDialog(options);
+    result.filePaths?.forEach((filePath) => approveVaultPath(filePath));
+    return result;
   });
 
   ipcMain.handle('desktop:showSaveDialog', async (_event, options: Electron.SaveDialogOptions) => {
     const owner = getMainWindow();
-    return owner ? dialog.showSaveDialog(owner, options) : dialog.showSaveDialog(options);
+    const result = owner ? await dialog.showSaveDialog(owner, options) : await dialog.showSaveDialog(options);
+    approveVaultPath(result.filePath);
+    return result;
   });
 
-  ipcMain.handle('desktop:openPath', async (_event, targetPath: string) => shell.openPath(targetPath));
-  ipcMain.handle('desktop:showItemInFolder', (_event, targetPath: string) => shell.showItemInFolder(targetPath));
+  ipcMain.handle('desktop:openPath', async (_event, targetPath: string) => {
+    return shell.openPath(resolveInsideCurrentVault(targetPath));
+  });
+  ipcMain.handle('desktop:showItemInFolder', (_event, targetPath: string) => {
+    shell.showItemInFolder(resolveInsideCurrentVault(targetPath));
+  });
   ipcMain.handle('desktop:getPath', (_event, name: Parameters<typeof app.getPath>[0]) => app.getPath(name));
+
+  ipcMain.handle('desktop:renamePath', async (_event, oldPath: string, newPath: string) => {
+    if (!oldPath || !newPath) throw new Error('Missing path');
+    if (!isApprovedVaultPath(oldPath)) {
+      throw new Error('Source vault is not approved');
+    }
+    const resolvedOld = nodePath.resolve(oldPath);
+    const resolvedNew = nodePath.resolve(newPath);
+    const sourceParent = nodePath.dirname(resolvedOld);
+    const destParent = nodePath.dirname(resolvedNew);
+    if (destParent !== sourceParent && !isApprovedVaultPath(destParent)) {
+      throw new Error('Destination is not approved');
+    }
+    await fs.rename(resolvedOld, resolvedNew);
+    approveVaultPath(resolvedNew);
+  });
 
   // ── File Operations ───────────────────────────────
   ipcMain.handle('fs:listFiles', async (_event, dirPath?: string) => {
@@ -212,7 +258,7 @@ export function registerIpcHandlers(
   // ── Network (CORS Bypass) ─────────────────────────
   ipcMain.handle('data:fetch', async (_event, url: string) => {
     try {
-      const res = await fetch(url, {
+      const res = await fetch(assertPublicHttpUrl(url), {
         headers: {
           'User-Agent': 'OpenOnyx/1.0',
           'Accept': 'application/json, text/plain, */*',
@@ -305,7 +351,7 @@ export function registerIpcHandlers(
 
   ipcMain.handle('network:request', async (_event, params: any) => {
     try {
-      const url = params.url;
+      const url = assertPublicHttpUrl(params?.url);
       const options: RequestInit = {
         method: params.method || 'GET',
         headers: {

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -14,6 +14,7 @@ import { FileSystemManager } from './fileSystem.js';
 import { SearchEngine } from './search.js';
 import { registerIpcHandlers } from './ipc.js';
 import { isInsideRoot } from './pathSafety.js';
+import { approveVaultPath } from './vaultAccess.js';
 
 // Register vault:// protocol as privileged before app is ready
 protocol.registerSchemesAsPrivileged([
@@ -645,7 +646,9 @@ app.whenReady().then(() => {
           properties: ['openDirectory'],
           title: 'Select Vault Directory',
         });
-    return result.canceled ? null : result.filePaths[0];
+    if (result.canceled || !result.filePaths[0]) return null;
+    approveVaultPath(result.filePaths[0]);
+    return result.filePaths[0];
   });
 
   buildMenu();

--- a/electron/outboundUrl.ts
+++ b/electron/outboundUrl.ts
@@ -1,0 +1,52 @@
+/** Validate a URL before the main process fetches it on behalf of the renderer. */
+
+const ALLOWED_PROTOCOLS = new Set(["http:", "https:"]);
+
+function isBlockedIpv4(hostname: string): boolean {
+  const match = hostname.match(/^(\d{1,3})\.(\d{1,3})\.(\d{1,3})\.(\d{1,3})$/);
+  if (!match) return false;
+  const octets = match.slice(1).map(Number);
+  if (octets.some((part) => part > 255)) return true;
+  const [a, b] = octets;
+  if (a === 0 || a === 10 || a === 127) return true;
+  if (a === 169 && b === 254) return true;
+  if (a === 172 && b >= 16 && b <= 31) return true;
+  if (a === 192 && b === 168) return true;
+  if (a === 100 && b >= 64 && b <= 127) return true;
+  return false;
+}
+
+function isBlockedHost(hostname: string): boolean {
+  const host = hostname.toLowerCase().replace(/^\[|\]$/g, "");
+  if (!host) return true;
+  if (host === "localhost" || host.endsWith(".localhost") || host.endsWith(".local")) return true;
+  if (host === "0.0.0.0" || host === "::" || host === "::1") return true;
+  if (host === "metadata.google.internal") return true;
+  if (host.startsWith("fe80:") || host.startsWith("fc") || host.startsWith("fd")) return true;
+  if (host.startsWith("::ffff:")) return isBlockedHost(host.slice(7));
+  return isBlockedIpv4(host);
+}
+
+/** Return a normalized public http(s) URL or throw. */
+export function assertPublicHttpUrl(value: unknown): string {
+  if (typeof value !== "string" || !value.trim()) {
+    throw new Error("A URL is required.");
+  }
+
+  let url: URL;
+  try {
+    url = new URL(value.trim());
+  } catch {
+    throw new Error("Invalid URL.");
+  }
+
+  if (!ALLOWED_PROTOCOLS.has(url.protocol)) {
+    throw new Error(`Outbound URL protocol is not allowed: ${url.protocol}`);
+  }
+
+  if (isBlockedHost(url.hostname)) {
+    throw new Error("Outbound URL host is not allowed.");
+  }
+
+  return url.href;
+}

--- a/electron/pathSafety.ts
+++ b/electron/pathSafety.ts
@@ -24,3 +24,16 @@ export function isSafeVaultProtocolPath(vaultPath: string, relativePath: string)
   const resolved = path.resolve(vaultPath, cleaned);
   return isInsideRoot(vaultPath, resolved);
 }
+
+/** Basename-only attachment name that cannot walk out of the attachments folder. */
+export function sanitizeAttachmentFileName(fileName: string): string {
+  const base = path.basename(fileName || "").trim();
+  if (!base || base === "." || base === "..") {
+    throw new Error("Invalid attachment file name");
+  }
+  const ext = path.extname(base);
+  if (ext && !/^\.[A-Za-z0-9]{1,8}$/.test(ext)) {
+    throw new Error("Invalid attachment file extension");
+  }
+  return base;
+}

--- a/electron/vaultAccess.ts
+++ b/electron/vaultAccess.ts
@@ -1,0 +1,24 @@
+import * as path from "path";
+
+const approvedVaultPaths = new Set<string>();
+
+export function normalizeApprovedPath(targetPath: string): string {
+  return path.resolve(targetPath);
+}
+
+export function approveVaultPath(targetPath: string | null | undefined): void {
+  if (!targetPath) return;
+  approvedVaultPaths.add(normalizeApprovedPath(targetPath));
+}
+
+export function seedApprovedVaultPaths(paths: Array<string | null | undefined>): void {
+  approvedVaultPaths.clear();
+  for (const entry of paths) {
+    approveVaultPath(entry);
+  }
+}
+
+export function isApprovedVaultPath(targetPath: string): boolean {
+  if (!targetPath) return true;
+  return approvedVaultPaths.has(normalizeApprovedPath(targetPath));
+}

--- a/src/components/editor/MarkdownPreview.tsx
+++ b/src/components/editor/MarkdownPreview.tsx
@@ -24,6 +24,7 @@ import { marked } from "marked";
 import markedKatex from "marked-katex-extension";
 import DOMPurify from "dompurify";
 import { resolveVaultImageSrc } from "../../utils/resolveImageSrc";
+import { bindPreviewMediaFallbacks, sanitizePreviewHtml } from "../../utils/previewSanitize";
 import { getSmartEmbed, getDisplayDomain, cleanEmbedUrl, toggleUrlInMarkdown } from "../../utils/urlHelper";
 import { runMarkdownPostProcessors } from "../../lib/obsidian-api/markdown";
 import type { AppSettings } from "../settings/SettingsPage";
@@ -640,7 +641,7 @@ export function MarkdownPreview({
       return `<div class="url-preview-card link-only" data-url="${url}" style="position: relative; ${cardStyle}">
         <div class="url-preview-header">
           <div class="url-preview-info">
-            <img class="url-preview-favicon" src="${faviconUrl}" alt="" onerror="this.style.display='none'">
+            <img class="url-preview-favicon" src="${faviconUrl}" alt="">
             <span class="url-preview-title">${displayDomain}</span>
           </div>
           <div class="url-preview-actions">
@@ -836,12 +837,7 @@ export function MarkdownPreview({
     });
 
     // Sanitize
-    return DOMPurify.sanitize(html, {
-      ALLOWED_URI_REGEXP: /^(?:(?:(?:f|ht)tps?|mailto|tel|callto|cid|xmpp|vault):|[^a-z]|[a-z+.\-]+(?:[^a-z+.\-:]|$))/i,
-      ADD_ATTR: ["data-link", "data-tag", "data-line", "data-heading", "data-embed", "data-callout", "data-foldable", "data-collapsed", "data-theme", "data-video-id", "data-url", "data-active-player", "checked", "type", "style", "frameborder", "allow", "allowfullscreen", "scrolling", "width", "height", "sandbox", "src", "onmouseover", "onmouseout", "onerror", "viewBox", "fill", "stroke", "stroke-width", "stroke-linecap", "stroke-linejoin", "cx", "cy", "r", "x", "y", "rx", "ry", "x1", "y1", "x2", "y2", "d"],
-      ADD_TAGS: ["span", "input", "math", "semantics", "mrow", "mi", "mo", "mn", "msup", "mspace", "msqrt", "mfrac", "table", "tbody", "tr", "mtd", "mtr", "annotation", "iframe", "blockquote", "div", "svg", "path", "circle", "line", "rect", "polyline"],
-      ADD_DATA_URI_TAGS: ["img"],
-    });
+    return sanitizePreviewHtml(html);
   }, [debouncedContent, onEmbed, theme, getSmartEmbed, getUrlPreviewMarkup]);
 
   // Handle clicks on wiki-links, tags, and checkboxes
@@ -1003,6 +999,7 @@ export function MarkdownPreview({
     if (lastHtmlRef.current !== renderedHtml || processorVersion > 0) {
       previewRef.current.innerHTML = renderedHtml;
       lastHtmlRef.current = renderedHtml;
+      bindPreviewMediaFallbacks(previewRef.current);
     }
 
     // Function to upgrade YouTube iframes into HD Posters
@@ -1012,7 +1009,7 @@ export function MarkdownPreview({
       if (iframe.dataset.hdPosterApplied || iframe.dataset.activePlayer === "true") return;
 
       const videoId = src.match(/(?:youtube\.com\/watch\?v=|youtu\.be\/|youtube\.com\/embed\/)([^&?]+)/)?.[1];
-      if (!videoId) return;
+      if (!videoId || !/^[A-Za-z0-9_-]{6,20}$/.test(videoId)) return;
 
       iframe.dataset.hdPosterApplied = "true";
 
@@ -1023,19 +1020,36 @@ export function MarkdownPreview({
       wrapper.className = "yt-hd-poster";
       wrapper.style.cssText = "position: relative; width: 100%; aspect-ratio: 16 / 9; border-radius: 12px; overflow: hidden; background: #000; cursor: pointer; margin: 16px 0;";
 
-      wrapper.innerHTML = `
-        <img class="yt-poster-img" src="${hdThumb}" onerror="this.src='${hqThumb}'" style="position: absolute; top: 0; left: 0; width: 100%; height: 100%; object-fit: cover; transition: opacity 0.2s;">
-        <div style="position: absolute; top: 50%; left: 50%; transform: translate(-50%, -50%); width: 68px; height: 48px; background: rgba(255, 0, 0, 0.9); border-radius: 12px; display: flex; align-items: center; justify-content: center; pointer-events: none; box-shadow: none;">
-          <svg viewBox="0 0 24 24" style="width: 32px; height: 32px; fill: white;"><path d="M8 5v14l11-7z"/></svg>
-        </div>
-      `;
+      const poster = document.createElement("img");
+      poster.className = "yt-poster-img";
+      poster.src = hdThumb;
+      poster.style.cssText = "position: absolute; top: 0; left: 0; width: 100%; height: 100%; object-fit: cover; transition: opacity 0.2s;";
+      poster.addEventListener("error", () => {
+        poster.src = hqThumb;
+      });
 
-      wrapper.onmouseover = () => { (wrapper.querySelector('img') as HTMLImageElement).style.opacity = '0.8'; };
-      wrapper.onmouseout = () => { (wrapper.querySelector('img') as HTMLImageElement).style.opacity = '1'; };
+      const playBadge = document.createElement("div");
+      playBadge.style.cssText = "position: absolute; top: 50%; left: 50%; transform: translate(-50%, -50%); width: 68px; height: 48px; background: rgba(255, 0, 0, 0.9); border-radius: 12px; display: flex; align-items: center; justify-content: center; pointer-events: none; box-shadow: none;";
+      playBadge.innerHTML = `<svg viewBox="0 0 24 24" style="width: 32px; height: 32px; fill: white;"><path d="M8 5v14l11-7z"/></svg>`;
 
-      wrapper.onclick = () => {
-        wrapper.innerHTML = `<iframe data-active-player="true" class="url-preview-iframe" src="https://www.youtube.com/embed/${videoId}?autoplay=1&vq=hd1080" allow="fullscreen; autoplay; clipboard-write; encrypted-media; picture-in-picture" allowfullscreen style="width:100%; height:100%; border:none; border-radius: 12px;"></iframe>`;
-      };
+      wrapper.append(poster, playBadge);
+      wrapper.addEventListener("mouseover", () => {
+        poster.style.opacity = "0.8";
+      });
+      wrapper.addEventListener("mouseout", () => {
+        poster.style.opacity = "1";
+      });
+
+      wrapper.addEventListener("click", () => {
+        const player = document.createElement("iframe");
+        player.dataset.activePlayer = "true";
+        player.className = "url-preview-iframe";
+        player.src = `https://www.youtube.com/embed/${videoId}?autoplay=1&vq=hd1080`;
+        player.allow = "fullscreen; autoplay; clipboard-write; encrypted-media; picture-in-picture";
+        player.allowFullscreen = true;
+        player.style.cssText = "width:100%; height:100%; border:none; border-radius: 12px;";
+        wrapper.replaceChildren(player);
+      });
 
       if (iframe.parentNode) {
         iframe.parentNode.replaceChild(wrapper, iframe);

--- a/src/lib/pluginManager.ts
+++ b/src/lib/pluginManager.ts
@@ -43,6 +43,7 @@ import type {
   PluginPermission,
   PluginApprovals,
 } from '../types/plugin';
+import { DEFAULT_PLUGIN_PERMISSIONS } from '../types/plugin';
 
 import { getAPI } from '../utils/api';
 const api = () => getAPI();
@@ -69,9 +70,7 @@ const APP_VERSION = '1.13.1';
 const LOAD_TIMEOUT_MS = 8000;
 const MAX_PARALLEL_LOADS = 3;
 
-// Default permissions plugins get if manifest doesn't declare any
-// (Obsidian compat: existing plugins don't have permissions in manifest)
-const DEFAULT_PERMISSIONS: PluginPermission[] = ['filesystem', 'network', 'ui', 'editor'];
+const DEFAULT_PERMISSIONS = DEFAULT_PLUGIN_PERMISSIONS;
 
 export interface PluginBundleFiles {
   manifestText: string;
@@ -432,10 +431,17 @@ export class PluginManager {
         const home = (() => {
           try { return (window as any).require?.('os')?.homedir?.() || ''; } catch { return ''; }
         })();
+        const denyFilesystem = () => Promise.reject(new Error(`[Plugin:${manifest.id}] Filesystem access denied`));
         const shell = {
           ...(electron.shell || {}),
-          openPath: (targetPath: string) => bridge.openPath?.(targetPath) ?? Promise.resolve(''),
-          showItemInFolder: (targetPath: string) => bridge.showItemInFolder?.(targetPath),
+          openPath: (targetPath: string) =>
+            permissions.includes('filesystem')
+              ? (bridge.openPath?.(targetPath) ?? Promise.resolve(''))
+              : denyFilesystem(),
+          showItemInFolder: (targetPath: string) =>
+            permissions.includes('filesystem')
+              ? bridge.showItemInFolder?.(targetPath)
+              : denyFilesystem(),
           openExternal: (url: string) => bridge.openPath?.(url) ?? Promise.resolve(''),
         };
         return {

--- a/src/types/plugin.ts
+++ b/src/types/plugin.ts
@@ -11,6 +11,9 @@
 /** Granular permission types for plugin capabilities */
 export type PluginPermission = 'filesystem' | 'network' | 'ui' | 'editor' | 'system';
 
+/** Granted when a manifest omits permissions. Filesystem and network must be explicit. */
+export const DEFAULT_PLUGIN_PERMISSIONS: PluginPermission[] = ['ui', 'editor'];
+
 /** Human-readable descriptions for permission labels */
 export const PERMISSION_DESCRIPTIONS: Record<PluginPermission, { label: string; description: string; risk: 'low' | 'medium' | 'high' }> = {
   filesystem: {

--- a/src/utils/previewSanitize.ts
+++ b/src/utils/previewSanitize.ts
@@ -1,0 +1,93 @@
+import DOMPurify from "dompurify";
+
+/** Attributes preview HTML may keep. Event handlers are intentionally absent. */
+export const PREVIEW_ADD_ATTR = [
+  "data-link",
+  "data-tag",
+  "data-line",
+  "data-heading",
+  "data-embed",
+  "data-callout",
+  "data-foldable",
+  "data-collapsed",
+  "data-theme",
+  "data-video-id",
+  "data-url",
+  "data-active-player",
+  "checked",
+  "type",
+  "style",
+  "frameborder",
+  "allow",
+  "allowfullscreen",
+  "scrolling",
+  "width",
+  "height",
+  "sandbox",
+  "src",
+  "viewBox",
+  "fill",
+  "stroke",
+  "stroke-width",
+  "stroke-linecap",
+  "stroke-linejoin",
+  "cx",
+  "cy",
+  "r",
+  "x",
+  "y",
+  "rx",
+  "ry",
+  "x1",
+  "y1",
+  "x2",
+  "y2",
+  "d",
+];
+
+export function sanitizePreviewHtml(html: string): string {
+  return DOMPurify.sanitize(html, {
+    ALLOWED_URI_REGEXP:
+      /^(?:(?:(?:f|ht)tps?|mailto|tel|callto|cid|xmpp|vault):|[^a-z]|[a-z+.\-]+(?:[^a-z+.\-:]|$))/i,
+    ADD_ATTR: PREVIEW_ADD_ATTR,
+    ADD_TAGS: [
+      "span",
+      "input",
+      "math",
+      "semantics",
+      "mrow",
+      "mi",
+      "mo",
+      "mn",
+      "msup",
+      "mspace",
+      "msqrt",
+      "mfrac",
+      "table",
+      "tbody",
+      "tr",
+      "mtd",
+      "mtr",
+      "annotation",
+      "iframe",
+      "blockquote",
+      "div",
+      "svg",
+      "path",
+      "circle",
+      "line",
+      "rect",
+      "polyline",
+    ],
+    ADD_DATA_URI_TAGS: ["img"],
+  });
+}
+
+/** Hide broken preview favicons without keeping onerror in sanitized HTML. */
+export function bindPreviewMediaFallbacks(root: ParentNode): void {
+  root.querySelectorAll<HTMLImageElement>("img.url-preview-favicon").forEach((img) => {
+    img.addEventListener("error", () => {
+      img.style.display = "none";
+    });
+  });
+}

--- a/supabase/functions/_shared/requireUser.ts
+++ b/supabase/functions/_shared/requireUser.ts
@@ -1,0 +1,36 @@
+import { createClient } from "npm:@supabase/supabase-js@2";
+
+export async function requireUser(req: Request): Promise<{ userId: string } | Response> {
+  const authHeader = req.headers.get("Authorization") || "";
+  if (!authHeader.toLowerCase().startsWith("bearer ")) {
+    return new Response(JSON.stringify({ error: "Authorization bearer token is required" }), {
+      status: 401,
+      headers: { "Content-Type": "application/json", "Access-Control-Allow-Origin": "*" },
+    });
+  }
+
+  const supabaseUrl = Deno.env.get("SUPABASE_URL");
+  const anonKey = Deno.env.get("SUPABASE_ANON_KEY");
+  if (!supabaseUrl || !anonKey) {
+    return new Response(JSON.stringify({ error: "Auth is not configured on the server" }), {
+      status: 500,
+      headers: { "Content-Type": "application/json", "Access-Control-Allow-Origin": "*" },
+    });
+  }
+
+  const supabase = createClient(supabaseUrl, anonKey, {
+    global: { headers: { Authorization: authHeader } },
+    auth: { persistSession: false, autoRefreshToken: false },
+  });
+
+  const token = authHeader.slice(7).trim();
+  const { data, error } = await supabase.auth.getUser(token);
+  if (error || !data.user) {
+    return new Response(JSON.stringify({ error: "Unauthorized" }), {
+      status: 401,
+      headers: { "Content-Type": "application/json", "Access-Control-Allow-Origin": "*" },
+    });
+  }
+
+  return { userId: data.user.id };
+}

--- a/supabase/functions/chat/index.ts
+++ b/supabase/functions/chat/index.ts
@@ -2,6 +2,7 @@
 /// <reference path="../types.d.ts" />
 import "jsr:@supabase/functions-js/edge-runtime.d.ts";
 import OpenAI from 'npm:openai';
+import { requireUser } from '../_shared/requireUser.ts';
 
 const openai = new OpenAI({
   apiKey: Deno.env.get('OPENAI_API_KEY'),
@@ -11,6 +12,9 @@ Deno.serve(async (req: Request) => {
   if (req.method === 'OPTIONS') {
     return new Response('ok', { headers: { 'Access-Control-Allow-Origin': '*', 'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type' } });
   }
+
+  const auth = await requireUser(req);
+  if (auth instanceof Response) return auth;
 
   try {
     const { messages } = await req.json();

--- a/supabase/functions/embed/index.ts
+++ b/supabase/functions/embed/index.ts
@@ -2,6 +2,7 @@
 // @ts-nocheck
 import "jsr:@supabase/functions-js/edge-runtime.d.ts";
 import OpenAI from 'npm:openai';
+import { requireUser } from '../_shared/requireUser.ts';
 
 const openai = new OpenAI({
   apiKey: Deno.env.get('OPENAI_API_KEY'),
@@ -11,6 +12,9 @@ Deno.serve(async (req: Request) => {
   if (req.method === 'OPTIONS') {
     return new Response('ok', { headers: { 'Access-Control-Allow-Origin': '*', 'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type' } });
   }
+
+  const auth = await requireUser(req);
+  if (auth instanceof Response) return auth;
 
   try {
     const { input } = await req.json();

--- a/tests/file-system-jail.test.ts
+++ b/tests/file-system-jail.test.ts
@@ -1,0 +1,40 @@
+import fs from "fs";
+import os from "os";
+import path from "path";
+import { afterEach, describe, expect, it } from "vitest";
+import { FileSystemManager } from "../electron/fileSystem";
+
+describe("filesystem jail", () => {
+  const dirs: string[] = [];
+
+  afterEach(() => {
+    for (const dir of dirs.splice(0)) {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  function makeVault(): { vault: string; manager: FileSystemManager } {
+    const vault = fs.mkdtempSync(path.join(os.tmpdir(), "oo-vault-"));
+    dirs.push(vault);
+    const manager = new FileSystemManager();
+    manager.setVaultPath(vault);
+    return { vault, manager };
+  }
+
+  it("refuses to read absolute paths outside the vault", async () => {
+    const { vault, manager } = makeVault();
+    const outside = path.join(os.tmpdir(), `oo-secret-${Date.now()}.txt`);
+    fs.writeFileSync(outside, "secret");
+    dirs.push(outside);
+    await expect(manager.readBinary(outside)).rejects.toThrow("Path traversal detected");
+  });
+
+  it("refuses attachment names that escape the attachments folder", async () => {
+    const { vault, manager } = makeVault();
+    const relative = await manager.saveImage("photo.png", "aaaa");
+    expect(relative).toBe("attachments/photo.png");
+    expect(fs.existsSync(path.join(vault, "attachments", "photo.png"))).toBe(true);
+    await expect(manager.saveImage("../escape.png", "aaaa")).resolves.toBe("attachments/escape.png");
+    expect(fs.existsSync(path.join(vault, "escape.png"))).toBe(false);
+  });
+});

--- a/tests/outbound-url.test.ts
+++ b/tests/outbound-url.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from "vitest";
+import { assertPublicHttpUrl } from "../electron/outboundUrl";
+
+describe("outbound URL policy", () => {
+  it("allows public http and https URLs", () => {
+    expect(assertPublicHttpUrl("https://raw.githubusercontent.com/org/repo/main/README.md")).toContain(
+      "https://raw.githubusercontent.com/",
+    );
+    expect(assertPublicHttpUrl("http://example.com/api")).toBe("http://example.com/api");
+  });
+
+  it.each([
+    "file:///etc/passwd",
+    "http://localhost:8765/build",
+    "http://127.0.0.1/",
+    "http://192.168.1.1/",
+    "http://10.0.0.5/",
+    "http://169.254.169.254/latest/meta-data/",
+    "http://[::1]/",
+    "ftp://example.com/a",
+  ])("rejects %s", (url) => {
+    expect(() => assertPublicHttpUrl(url)).toThrow();
+  });
+});

--- a/tests/path-safety.test.ts
+++ b/tests/path-safety.test.ts
@@ -4,6 +4,7 @@ import {
   isInsideRoot,
   isSafeVaultProtocolPath,
   resolveInsideRoot,
+  sanitizeAttachmentFileName,
 } from "../electron/pathSafety";
 
 describe("path safety", () => {
@@ -29,5 +30,12 @@ describe("path safety", () => {
   it("blocks vault:// paths that walk out of the vault", () => {
     expect(isSafeVaultProtocolPath(root, "attachments/a.png")).toBe(true);
     expect(isSafeVaultProtocolPath(root, "../../etc/passwd")).toBe(false);
+  });
+
+  it("keeps attachment names inside the attachments folder", () => {
+    expect(sanitizeAttachmentFileName("../../etc/passwd.png")).toBe("passwd.png");
+    expect(sanitizeAttachmentFileName("photo.jpg")).toBe("photo.jpg");
+    expect(() => sanitizeAttachmentFileName("..")).toThrow("Invalid attachment file name");
+    expect(() => sanitizeAttachmentFileName("note.toolongext")).toThrow("Invalid attachment file extension");
   });
 });

--- a/tests/plugin-permissions.test.ts
+++ b/tests/plugin-permissions.test.ts
@@ -1,0 +1,10 @@
+import { describe, expect, it } from "vitest";
+import { DEFAULT_PLUGIN_PERMISSIONS } from "../src/types/plugin";
+
+describe("default plugin permissions", () => {
+  it("does not grant filesystem or network until the plugin declares them", () => {
+    expect(DEFAULT_PLUGIN_PERMISSIONS).toEqual(["ui", "editor"]);
+    expect(DEFAULT_PLUGIN_PERMISSIONS).not.toContain("filesystem");
+    expect(DEFAULT_PLUGIN_PERMISSIONS).not.toContain("network");
+  });
+});

--- a/tests/preview-sanitize.test.ts
+++ b/tests/preview-sanitize.test.ts
@@ -1,0 +1,17 @@
+// @vitest-environment jsdom
+import { describe, expect, it } from "vitest";
+import { PREVIEW_ADD_ATTR, sanitizePreviewHtml } from "../src/utils/previewSanitize";
+
+describe("preview HTML sanitizer", () => {
+  it("does not allow event-handler attributes", () => {
+    expect(PREVIEW_ADD_ATTR).not.toContain("onerror");
+    expect(PREVIEW_ADD_ATTR).not.toContain("onmouseover");
+    expect(PREVIEW_ADD_ATTR).not.toContain("onmouseout");
+  });
+
+  it("strips onerror from user markdown HTML", () => {
+    const html = sanitizePreviewHtml('<img src="x" onerror="window.pwned=1">');
+    expect(html.toLowerCase()).not.toContain("onerror");
+    expect(html.toLowerCase()).not.toContain("pwned");
+  });
+});

--- a/tests/vault-access.test.ts
+++ b/tests/vault-access.test.ts
@@ -1,0 +1,25 @@
+import path from "path";
+import { beforeEach, describe, expect, it } from "vitest";
+import {
+  approveVaultPath,
+  isApprovedVaultPath,
+  seedApprovedVaultPaths,
+} from "../electron/vaultAccess";
+
+describe("approved vault paths", () => {
+  beforeEach(() => {
+    seedApprovedVaultPaths([]);
+  });
+
+  it("rejects unknown renderer-supplied paths", () => {
+    expect(isApprovedVaultPath("")).toBe(true);
+    expect(isApprovedVaultPath("/tmp/not-a-known-vault")).toBe(false);
+  });
+
+  it("accepts dialog-approved and previously opened vaults", () => {
+    const vault = path.resolve("/tmp/openonyx-approved-vault");
+    approveVaultPath(vault);
+    expect(isApprovedVaultPath(vault)).toBe(true);
+    expect(isApprovedVaultPath("/Users/me")).toBe(false);
+  });
+});


### PR DESCRIPTION
## Why

A desktop app cannot be “unhackable,” but untrusted markdown and plugins currently have a path to the whole machine. Preview XSS plus unrestricted IPC is enough to retarget the vault, read arbitrary files, open local binaries, and fetch `localhost`.

This PR implements harden items **1–6** from the security review. Item 7 (`openExternal`) already landed from #100 and is preserved here.

Supersedes #102, which conflicted with `main` after #95 (Mermaid) and #100 (`openExternal`) merged. Repository rules block force-push and direct updates to the old branch, so this is a clean replay on current `main`.

## What changed

### 1. Preview XSS
- Removed `onerror` / `onmouseover` / `onmouseout` from DOMPurify `ADD_ATTR`.
- Favicon hide-on-error and YouTube poster fallbacks are bound in code after sanitize.
- YouTube IDs are restricted to a safe character set before building URLs.
- Mermaid rendering from #95 is kept.

### 2. Filesystem jail
- `readBinary` no longer accepts raw absolute paths; everything goes through `resolveInsideRoot`.
- `saveImage` / `saveAttachmentDedup` basename the file name and write only under `attachments/`.

### 3. `setVaultPath` is no longer free-form
- Renderer may only set a vault that was chosen in a folder/save dialog or is already in vault history.
- Empty path still clears the vault.
- Added the missing `desktop:renamePath` handler so rename/move can approve the destination.

### 4. `openPath` / `data:fetch` / `network:request`
- `openPath` and `showItemInFolder` must resolve inside the **active** vault.
- Outbound fetches allow only public `http:` / `https:`. Localhost, link-local, and RFC1918 addresses are rejected.
- `desktop:openExternal` from #100 is unchanged and still uses `allowedExternalUrl`.

### 5. Edge Functions
- `chat` and `embed` require a Supabase user JWT before using `OPENAI_API_KEY`.
- If these functions are already deployed, redeploy them or the old unauthenticated versions stay live.

### 6. Plugin defaults
- Manifests that omit permissions now get `ui` + `editor` only.
- `require('electron').shell.openPath` / `showItemInFolder` are denied without the `filesystem` permission.
- Plugin `openExternal` still goes through `bridge.openExternal` (#100).
- Existing approvals in `plugin-permissions.json` are unchanged.

## Verification

- `npm run lint`
- `npm test` — 165 passed (includes #100 external-URL IPC tests)

## Merge notes

- Close #102 as superseded after this is up.
- After merge, deploy the Edge Functions if you use them.