### PR TITLE
fix(security): reject outbound fetch redirects (for #103)

### DIFF
--- a/electron/ipc.ts
+++ b/electron/ipc.ts
@@ -11,7 +11,7 @@ import * as nodePath from 'path';
 import { FileSystemManager } from './fileSystem.js';
 import { SearchEngine } from './search.js';
 import { allowedExternalUrl } from './externalUrl.js';
-import { assertPublicHttpUrl } from './outboundUrl.js';
+import { fetchPublicHttp } from './outboundUrl.js';
 import { isInsideRoot } from './pathSafety.js';
 import { approveVaultPath, isApprovedVaultPath, seedApprovedVaultPaths } from './vaultAccess.js';
 
@@ -262,7 +262,7 @@ export function registerIpcHandlers(
   // ── Network (CORS Bypass) ─────────────────────────
   ipcMain.handle('data:fetch', async (_event, url: string) => {
     try {
-      const res = await fetch(assertPublicHttpUrl(url), {
+      const res = await fetchPublicHttp(url, {
         headers: {
           'User-Agent': 'OpenOnyx/1.0',
           'Accept': 'application/json, text/plain, */*',
@@ -355,17 +355,14 @@ export function registerIpcHandlers(
 
   ipcMain.handle('network:request', async (_event, params: any) => {
     try {
-      const url = assertPublicHttpUrl(params?.url);
-      const options: RequestInit = {
+      const res = await fetchPublicHttp(params?.url, {
         method: params.method || 'GET',
         headers: {
           'User-Agent': 'OpenOnyx/1.0',
           ...params.headers,
         },
         body: params.body,
-      };
-
-      const res = await fetch(url, options);
+      });
       const arrayBuffer = await res.arrayBuffer();
       
       // IPC can clone ArrayBuffer or Uint8Array

--- a/electron/outboundUrl.ts
+++ b/electron/outboundUrl.ts
@@ -50,3 +50,12 @@ export function assertPublicHttpUrl(value: unknown): string {
 
   return url.href;
 }
+
+/**
+ * Fetch a renderer-supplied URL without following redirects.
+ * Node's default `redirect: "follow"` would skip the host check on 3xx targets
+ * (localhost, RFC1918, metadata).
+ */
+export async function fetchPublicHttp(url: unknown, init: RequestInit = {}): Promise<Response> {
+  return fetch(assertPublicHttpUrl(url), { ...init, redirect: "error" });
+}

--- a/src/components/editor/MarkdownPreview.tsx
+++ b/src/components/editor/MarkdownPreview.tsx
@@ -1112,7 +1112,7 @@ export function MarkdownPreview({
 
             if (cancelled || !previewRef.current) return;
 
-            const isDarkTheme = themeMode === "dark" || themeMode.startsWith("dark-") ||themeMode.includes("dark");
+            const isDarkTheme = themeMode === "dark" || themeMode.startsWith("dark-") || themeMode.includes("dark");
 
             mermaid.initialize({
               startOnLoad: false,

--- a/tests/outbound-url.test.ts
+++ b/tests/outbound-url.test.ts
@@ -1,5 +1,5 @@
-import { describe, expect, it } from "vitest";
-import { assertPublicHttpUrl } from "../electron/outboundUrl";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { assertPublicHttpUrl, fetchPublicHttp } from "../electron/outboundUrl";
 
 describe("outbound URL policy", () => {
   it("allows public http and https URLs", () => {
@@ -20,5 +20,30 @@ describe("outbound URL policy", () => {
     "ftp://example.com/a",
   ])("rejects %s", (url) => {
     expect(() => assertPublicHttpUrl(url)).toThrow();
+  });
+
+  describe("fetchPublicHttp", () => {
+    afterEach(() => {
+      vi.unstubAllGlobals();
+      vi.restoreAllMocks();
+    });
+
+    it("rejects private hosts before calling fetch", async () => {
+      const fetchMock = vi.fn();
+      vi.stubGlobal("fetch", fetchMock);
+      await expect(fetchPublicHttp("http://127.0.0.1/secret")).rejects.toThrow(
+        "Outbound URL host is not allowed.",
+      );
+      expect(fetchMock).not.toHaveBeenCalled();
+    });
+
+    it("does not follow redirects so a public URL cannot hop to loopback", async () => {
+      const fetchMock = vi.fn().mockResolvedValue({ ok: true });
+      vi.stubGlobal("fetch", fetchMock);
+      await fetchPublicHttp("https://example.com/redirect", { redirect: "follow", method: "GET" });
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+      const [, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+      expect(init.redirect).toBe("error");
+    });
   });
 });


### PR DESCRIPTION
## Why

Repository rules block direct pushes to `security/harden-renderer-ipc-rebased`, so this is the follow-up for the open review comments on #103.

## What

1. **SSRF redirect bypass** — `data:fetch` and `network:request` now go through `fetchPublicHttp`, which always sets `redirect: "error"`. A public URL can no longer 3xx into localhost / RFC1918 / metadata. Covered by unit tests.
2. **Style** — missing space before `themeMode.includes("dark")` in `MarkdownPreview.tsx`.

`npm test` — 167 passed. `npm run lint` — clean.

Merge this into #103, then #103 is the merge to `main`.