### PR TITLE
feat(website): rebuild docs as a themed documentation site

### DIFF
--- a/website/src/components/SiteHeader.tsx
+++ b/website/src/components/SiteHeader.tsx
@@ -58,9 +58,6 @@ export function SiteHeader() {
             </NavLink>
             <NavLink to="/docs">docs</NavLink>
             <NavLink to="/download">download</NavLink>
-            <a href={PRODUCT.repo} target="_blank" rel="noreferrer">
-              source
-            </a>
           </nav>
         </div>
         <div className="header-meta">
@@ -72,28 +69,28 @@ export function SiteHeader() {
             title={theme === "light" ? "Dark mode" : "Light mode"}
           >
             {theme === "light" ? (
-              <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.75" strokeLinecap="round" aria-hidden>
+              <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.75" strokeLinecap="round" aria-hidden>
                 <circle cx="12" cy="12" r="4" />
                 <path d="M12 3v2M12 19v2M5.2 5.2l1.4 1.4M17.4 17.4l1.4 1.4M3 12h2M19 12h2M5.2 18.8l1.4-1.4M17.4 6.6l1.4-1.4" />
               </svg>
             ) : (
-              <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.75" strokeLinecap="round" strokeLinejoin="round" aria-hidden>
+              <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.75" strokeLinecap="round" strokeLinejoin="round" aria-hidden>
                 <path d="M21 14.3A8.4 8.4 0 1 1 9.7 3 6.6 6.6 0 0 0 21 14.3z" />
               </svg>
             )}
           </button>
           <button
             type="button"
-            className="meta-chip"
+            className="meta-chip meta-chip-palette"
             onClick={() => window.dispatchEvent(new Event("openonyx:palette"))}
           >
             ⌘K
           </button>
-          <a className="meta-chip" href={PRODUCT.latestRelease} target="_blank" rel="noreferrer">
+          <a className="meta-chip meta-chip-version" href={PRODUCT.latestRelease} target="_blank" rel="noreferrer">
             v{PRODUCT.version}
           </a>
-          <a className="meta-chip" href={`${PRODUCT.repo}/stargazers`} target="_blank" rel="noreferrer">
-            <svg width="12" height="12" viewBox="0 0 16 16" fill="currentColor" aria-hidden>
+          <a className="meta-chip meta-chip-github" href={`${PRODUCT.repo}/stargazers`} target="_blank" rel="noreferrer">
+            <svg width="14" height="14" viewBox="0 0 16 16" fill="currentColor" aria-hidden>
               <path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27s1.36.09 2 .27c1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.01 8.01 0 0 0 16 8c0-4.42-3.58-8-8-8" />
             </svg>
             <span>{stars !== null ? formatCount(stars) : "github"}</span>
@@ -117,8 +114,8 @@ export function SiteHeader() {
         </NavLink>
         <NavLink to="/docs">docs</NavLink>
         <NavLink to="/download">download</NavLink>
-        <a href={PRODUCT.repo} target="_blank" rel="noreferrer">
-          source
+        <a href={`${PRODUCT.repo}/stargazers`} target="_blank" rel="noreferrer">
+          GitHub
         </a>
       </nav>
     </header>

--- a/website/src/data/docs.tsx
+++ b/website/src/data/docs.tsx
@@ -1,7 +1,70 @@
 import type { ReactNode } from "react";
 import { Link } from "react-router-dom";
 import { CompareTable } from "../components/CompareTable";
-import { FEATURES, PLUGINS_TESTED, PRODUCT, SHORTCUTS } from "./facts";
+import { DOWNLOADS, FEATURES, PLUGINS_TESTED, PRODUCT, SHORTCUTS } from "./facts";
+
+function Steps({ items }: { items: Array<{ title: string; body: ReactNode }> }) {
+  return (
+    <ol className="docs-steps">
+      {items.map((item) => (
+        <li key={item.title}>
+          <b>{item.title}</b>
+          <p>{item.body}</p>
+        </li>
+      ))}
+    </ol>
+  );
+}
+
+function Note({ children }: { children: ReactNode }) {
+  return (
+    <div className="docs-note">
+      <strong>Note</strong>
+      <div>{children}</div>
+    </div>
+  );
+}
+
+function Caution({ children }: { children: ReactNode }) {
+  return (
+    <div className="docs-note is-caution">
+      <strong>Caution</strong>
+      <div>{children}</div>
+    </div>
+  );
+}
+
+function Hub({
+  title,
+  blurb,
+  more,
+  links,
+}: {
+  title: string;
+  blurb: string;
+  more?: { to: string; label: string };
+  links: Array<{ to: string; title: string; body: string }>;
+}) {
+  return (
+    <section className="docs-hub">
+      <h2>{title}</h2>
+      <p>{blurb}</p>
+      <ul>
+        {links.map((link) => (
+          <li key={link.to}>
+            <Link to={link.to}>{link.title}</Link>
+            <span> — {link.body}</span>
+          </li>
+        ))}
+      </ul>
+      {more && (
+        <p className="docs-hub-more">
+          <Link to={more.to}>{more.label}</Link>
+        </p>
+      )}
+    </section>
+  );
+}
 
 export type DocPage = {
   slug: string;
@@ -14,45 +77,72 @@ export type DocPage = {
 export const DOC_PAGES: DocPage[] = [
   {
     slug: "start",
-    title: "Start here",
+    title: "Documentation",
     group: "Get going",
     summary:
-      "OpenOnyx is a local-first knowledge workspace with built-in Spaces, an AI graph, and an Apache-2.0 desktop. Files stay files.",
+      "OpenOnyx is an open source desktop app for notes you keep as files. This site is the official documentation for install, daily use, the built-in thinking layer, and optional cloud.",
     body: (
       <>
         <p>
-          OpenOnyx is a desktop knowledge app with the thinking layer already in the box. You point it at a
-          folder — a vault — and write Markdown files there. The editor, graph, search, Spaces, and AI graph
-          all read those files. Nothing important lives only inside the app database.
+          You point the app at a folder — a vault — and write Markdown there. The editor, graph, search,
+          Spaces, and plugins all read those files. Nothing important lives only inside the app. You do not
+          need an account to start.
         </p>
-        <div className="callout">
-          You do not need an account, a cloud project, or an API key to write, search, open the graph, or ask a
-          local Space. Those extras stay optional.
-        </div>
-        <h2>First ten minutes</h2>
-        <ol>
-          <li>
-            Install from <a href={PRODUCT.latestRelease}>v{PRODUCT.version} Releases</a>.
-          </li>
-          <li>Open a folder — a new vault, or the one you already use in Obsidian.</li>
-          <li>
-            Write a note. Link it with <code>[[Another note]]</code>.
-          </li>
-          <li>
-            <code>Ctrl/Cmd+G</code> opens the graph. <code>Ctrl/Cmd+P</code> opens the command palette.
-          </li>
-        </ol>
-        <h2>What stays on disk</h2>
-        <p>
-          Notes are <code>.md</code> files. Canvases are <code>.canvas</code> files. App cache lives in{" "}
-          <code>.openonyx</code> inside the vault. You can open the same folder in any other editor.
-        </p>
-        <h2>What ships in the desktop</h2>
-        <p>
-          Spaces, the AI graph, inline writing tools, an Obsidian-compatible plugin runtime, themes, wallpaper,
-          and optional cloud — not a catalog you assemble after install. The full list is on{" "}
-          <Link to="/docs/features">What's included</Link>.
-        </p>
+        <Note>
+          Current desktop release is v{PRODUCT.version} (Apache-2.0). Official builds are on{" "}
+          <a href={PRODUCT.latestRelease}>GitHub Releases</a>. A phone client is in progress and is not
+          documented here yet.
+        </Note>
+
+        <Hub
+          title="Get going"
+          blurb="Install the desktop, open a folder, and see what ships in the box."
+          more={{ to: "/docs/install", label: "Start with install" }}
+          links={[
+            { to: "/docs/install", title: "Install", body: "macOS, Windows, Linux, or build from source." },
+            { to: "/docs/vault", title: "Open a vault", body: "A vault is a folder. Create one or open one you already have." },
+            { to: "/docs/features", title: "What's included", body: "The twelve surfaces in the current desktop." },
+            { to: "/docs/obsidian", title: "Coming from Obsidian", body: "Open the same folder. Then use Spaces and the AI graph." },
+          ]}
+        />
+        <Hub
+          title="Daily use"
+          blurb="The work you do every day: write, find, map, and board."
+          more={{ to: "/docs/write", label: "Start writing" }}
+          links={[
+            { to: "/docs/write", title: "Write notes", body: "Source, preview, split, wiki links, Vim, and tables." },
+            { to: "/docs/find", title: "Find anything", body: "Quick switcher, vault search, and the command palette." },
+            { to: "/docs/graph", title: "Graph", body: "Wiki links as a map, plus a local AI view." },
+            { to: "/docs/canvas", title: "Canvas", body: "Portable .canvas boards next to your notes." },
+          ]}
+        />
+        <Hub
+          title="Thinking layer"
+          blurb="Ask the vault, load community plugins, and set the look. These ship in the desktop."
+          more={{ to: "/docs/spaces", label: "Open Spaces" }}
+          links={[
+            { to: "/docs/spaces", title: "Spaces and AI", body: "Local embeddings, cited answers, optional rewrite." },
+            { to: "/docs/plugins", title: "Plugins", body: "Obsidian-compatible runtime, marketplace, crash isolation." },
+            { to: "/docs/themes", title: "Themes and wallpaper", body: "Dark, light, oceanic, custom themes, vault wallpaper." },
+          ]}
+        />
+        <Hub
+          title="Optional cloud"
+          blurb="Writing never needs a server. Turn these on only if you want them."
+          more={{ to: "/docs/privacy", label: "Read the privacy model" }}
+          links={[
+            { to: "/docs/sync", title: "Sync and collaboration", body: "Your Supabase project. Live multiplayer is under maintenance." },
+            { to: "/docs/privacy", title: "Privacy", body: "Offline by default. No product telemetry." },
+          ]}
+        />
+        <Hub
+          title="Reference"
+          blurb="Look up shortcuts and how the desktop is put together."
+          links={[
+            { to: "/docs/shortcuts", title: "Keyboard", body: "Shortcuts wired in the current renderer." },
+            { to: "/docs/develop", title: "Develop", body: "Clone, run, and the process boundary." },
+          ]}
+        />
       </>
     ),
   },
@@ -61,12 +151,17 @@ export const DOC_PAGES: DocPage[] = [
     title: "What's included",
     group: "Get going",
     summary:
-      "Every surface that ships in OpenOnyx: editor, search, graph, AI graph, canvas, Spaces, writing tools, plugins, themes, privacy, optional cloud, and export.",
+      "Twelve surfaces ship in the desktop: writing, search, graph, AI graph, canvas, Spaces, AI writing, plugins, themes, privacy, optional cloud, and export. This page is the inventory, not a wishlist.",
     body: (
       <>
         <p>
-          OpenOnyx is the workspace plus the thinking layer. These are the features in the desktop app today —
-          not a wishlist, and not a plugin you have to hunt down first.
+          After install you already have the workspace and the thinking layer. You do not hunt a plugin to
+          ask the vault a question or to see a semantic graph. Below is what is in the current desktop build,
+          with a short “what it is” for each surface.
+        </p>
+        <p>
+          Coming from Obsidian? Open the same folder, then start with Spaces and the AI graph — those are the
+          layers they do not ship. See <Link to="/docs/obsidian">Coming from Obsidian</Link>.
         </p>
         {FEATURES.map((item) => (
           <section key={item.id}>
@@ -79,10 +174,10 @@ export const DOC_PAGES: DocPage[] = [
             </ul>
           </section>
         ))}
-        <div className="callout">
+        <Note>
           Coming from Obsidian? Open the same folder. Then use Spaces and the AI graph — those are the layers
           they do not ship. See <Link to="/docs/obsidian">Coming from Obsidian</Link>.
-        </div>
+        </Note>
       </>
     ),
   },
@@ -90,41 +185,44 @@ export const DOC_PAGES: DocPage[] = [
     slug: "install",
     title: "Install",
     group: "Get going",
-    summary: "macOS, Windows, Linux, and building from source.",
+    summary:
+      "Install the official desktop build for macOS, Windows, or Linux from GitHub Releases. Local writing needs no account. You can also build from source with Node.js 22.",
     body: (
       <>
         <p>
-          Official binaries are attached to{" "}
-          <a href={PRODUCT.releases}>GitHub Releases</a>. Current tagged version is {PRODUCT.version}.
+          OpenOnyx is an Electron desktop app. Download the installer for your OS from{" "}
+          <a href={PRODUCT.releases}>GitHub Releases</a> (current tag is {PRODUCT.version}), then open a
+          folder. After the window is up, go to <Link to="/docs/vault">Open a vault</Link>.
         </p>
         <h2>macOS</h2>
         <p>
-          Download the <code>.dmg</code> or <code>.zip</code> from the release and move the app to Applications.
+          Download the <code>.dmg</code> or <code>.zip</code> from the release. Drag OpenOnyx into
+          Applications, then launch it from there.
         </p>
-        <div className="callout">
-          If Gatekeeper says the app is from an unidentified developer or is damaged, right-click OpenOnyx.app →
-          Open, or run <code>xattr -cr /Applications/OpenOnyx.app</code>.
-        </div>
+        <Caution>{DOWNLOADS.macNote}</Caution>
         <h2>Windows</h2>
         <p>
-          Download the <code>.exe</code> installer. Signing is provided by SignPath.io with a certificate from
-          SignPath Foundation.
+          Download the <code>.exe</code> installer from the same release. Signing is provided by SignPath.io
+          with a certificate from SignPath Foundation.
         </p>
+        <Note>{DOWNLOADS.windowsNote}</Note>
         <h2>Linux</h2>
         <p>
-          Use <code>.AppImage</code>, <code>.deb</code>, or Arch <code>.pkg.tar.zst</code> from the current
-          release, or:
+          Use <code>.AppImage</code>, <code>.deb</code>, or Arch <code>.pkg.tar.zst</code>. There is no official{" "}
+          <code>.rpm</code>. You can also run the installer script:
         </p>
-        <pre>curl -fsSL https://raw.githubusercontent.com/OpenOnyx/OpenOnyx/main/scripts/install.sh | bash</pre>
+        <pre>{DOWNLOADS.linuxInstall}</pre>
         <h2>From source</h2>
-        <p>Requires Node.js 22 or newer (see package.json engines).</p>
+        <p>
+          Requires Node.js 22 or newer. This starts the Electron main process, Vite on port {PRODUCT.vitePort},
+          and the desktop window against that dev server.
+        </p>
         <pre>{`git clone https://github.com/OpenOnyx/OpenOnyx.git
 cd OpenOnyx
 npm install
 npm run dev`}</pre>
         <p>
-          That compiles the Electron main process, starts Vite on port {PRODUCT.vitePort}, and launches the
-          desktop window against it.
+          Next: <Link to="/docs/vault">open a vault</Link>, then <Link to="/docs/write">write a note</Link>.
         </p>
       </>
     ),
@@ -133,29 +231,52 @@ npm run dev`}</pre>
     slug: "vault",
     title: "Open a vault",
     group: "Get going",
-    summary: "A vault is a folder. Treat it like one.",
+    summary:
+      "A vault is any folder you choose. OpenOnyx reads the Markdown and canvas files in that folder and remembers recent vaults so you can switch without hunting the disk.",
     body: (
       <>
         <p>
-          A vault is any folder you choose. OpenOnyx remembers recently opened vaults so you can switch without
-          hunting through the disk.
+          Think of the vault as “this project’s notes folder,” not an account. You can keep a research vault, a
+          work vault, and a personal vault as three different folders and switch between them.
         </p>
         <h2>Create or open</h2>
-        <ul>
-          <li>The welcome flow can create a new vault folder or open an existing one.</li>
-          <li>
-            After a vault is open, <code>File → Open Vault</code> switches folders.{" "}
-            <code>Ctrl/Cmd+O</code> in the window is the note quick switcher.
-          </li>
-          <li>You can keep more than one vault — research, work, personal — and switch between them.</li>
-        </ul>
+        <Steps
+          items={[
+            {
+              title: "First launch",
+              body: "The welcome flow can create a new folder or open an existing one — including a folder you already use in Obsidian.",
+            },
+            {
+              title: "Switch later",
+              body: (
+                <>
+                  <code>File → Open Vault</code> changes folders. <code>Ctrl/Cmd+O</code> inside a vault is the
+                  note quick switcher, not “open another vault.”
+                </>
+              ),
+            },
+            {
+              title: "What the app writes",
+              body: (
+                <>
+                  Your notes stay <code>.md</code> files. Cache and indexes go in <code>.openonyx</code> inside
+                  the vault. You can ignore that folder in git if you want.
+                </>
+              ),
+            },
+          ]}
+        />
         <h2>Suggested layout</h2>
         <p>
-          The bundled test vault uses numbered PARA-style folders: <code>00 - Inbox</code>,{" "}
+          You do not have to use a special structure. Ordinary folders are the source of truth. The bundled
+          test vault happens to use numbered PARA-style folders — <code>00 - Inbox</code>,{" "}
           <code>01 - Projects</code>, <code>02 - Areas</code>, <code>03 - Resources</code>,{" "}
-          <code>04 - Archive</code>, daily notes, and templates. You do not have to use that layout. Ordinary
-          folders are the source of truth.
+          <code>04 - Archive</code> — plus daily notes and templates. Copy that only if it helps.
         </p>
+        <Note>
+          Coming from Obsidian? Point OpenOnyx at the same folder. Then read{" "}
+          <Link to="/docs/obsidian">Coming from Obsidian</Link> for what transfers and what you gain.
+        </Note>
       </>
     ),
   },
@@ -164,7 +285,7 @@ npm run dev`}</pre>
     title: "Coming from Obsidian",
     group: "Get going",
     summary:
-      "Open the same folder. Keep wiki links, graph, and canvas — then add built-in Spaces, an AI graph, and an Apache-2.0 desktop.",
+      "Open the folder you already have. Wiki links, graph, and canvas stay on disk. Then you get Spaces, an AI graph, and an Apache-2.0 desktop Obsidian does not ship.",
     body: (
       <>
         <p>
@@ -210,9 +331,7 @@ npm run dev`}</pre>
           </li>
           <li>Open Spaces and ask a question over the notes you already wrote.</li>
         </ol>
-        <div className="callout">
-          You can keep using Obsidian on the same folder. The files do not belong to either app.
-        </div>
+        <Note>You can keep using Obsidian on the same folder. The files do not belong to either app.</Note>
       </>
     ),
   },
@@ -220,20 +339,36 @@ npm run dev`}</pre>
     slug: "write",
     title: "Write notes",
     group: "Daily use",
-    summary: "CodeMirror workspace with source, preview, split, wiki links, Vim, KaTeX, and WYSIWYG tables.",
+    summary:
+      "Write in a CodeMirror workspace: source, live preview, or split. Wiki links, backlinks, KaTeX, Vim, and tables that edit as tables. The preview is sanitized.",
     body: (
       <>
         <p>
-          Writing happens in a CodeMirror editor. You can stay in source, use live preview, or split the pane.
-          Rendering is sanitized.
+          Click a file in the explorer, or press <code>Ctrl/Cmd+O</code> and type its name. The note opens as
+          a tab. You are editing the file on disk — save with <code>Ctrl/Cmd+S</code>.
         </p>
+        <h2>Three ways to look at the same file</h2>
+        <ul className="docs-points">
+          <li>
+            <b>Source</b>
+            <p>The Markdown as you typed it, with line numbers if you left them on.</p>
+          </li>
+          <li>
+            <b>Preview</b>
+            <p>Rendered reading view. HTML is sanitized before it is shown.</p>
+          </li>
+          <li>
+            <b>Split</b>
+            <p>Source on one side, preview on the other. This is the default on a wide window.</p>
+          </li>
+        </ul>
         <h2>Wiki links</h2>
         <p>
-          Link with <code>[[Note name]]</code>. Aliases and headings work: <code>[[Note|label]]</code>,{" "}
-          <code>[[Note#Heading]]</code>. Backlinks, outgoing links, and unlinked mentions show up in the right
-          sidebar.
+          Type <code>[[Note name]]</code>. Aliases and headings work: <code>[[Note|label]]</code>,{" "}
+          <code>[[Note#Heading]]</code>. Backlinks, outgoing links, and unlinked mentions show in the right
+          sidebar. The graph is those links drawn as a map.
         </p>
-        <h2>More of the editor</h2>
+        <h2>Also in the editor</h2>
         <ul>
           <li>KaTeX for math</li>
           <li>Tags, outline, and properties panels</li>
@@ -241,7 +376,7 @@ npm run dev`}</pre>
           <li>WYSIWYG tables — insert rows and columns without editing pipe syntax</li>
           <li>Tab groups, split panes, and recent files</li>
           <li>
-            In-editor formatting: <code>Ctrl/Cmd+B</code> bold, <code>Ctrl/Cmd+I</code> italic,{" "}
+            Formatting: <code>Ctrl/Cmd+B</code> bold, <code>Ctrl/Cmd+I</code> italic,{" "}
             <code>Ctrl/Cmd+E</code> or <code>Ctrl/Cmd+`</code> inline code,{" "}
             <code>Ctrl/Cmd+Shift+X</code> strikethrough
           </li>
@@ -253,27 +388,46 @@ npm run dev`}</pre>
     slug: "find",
     title: "Find anything",
     group: "Daily use",
-    summary: "Fuzzy vault search, quick switcher, command palette, bookmarks, and daily notes — built in.",
+    summary:
+      "Search the vault, jump to a note, or run a command without digging through folders. Bookmarks and daily notes are built in.",
     body: (
       <>
-        <p>Large vaults stay usable if you search first and browse second.</p>
-        <ul>
+        <p>
+          In a large folder, browsing the tree is the slow path. Use search first. Each shortcut below does one
+          job — they are not aliases of each other.
+        </p>
+        <ul className="docs-points">
           <li>
-            <code>Ctrl/Cmd+Shift+F</code> — fuzzy search across the vault
+            <b>
+              <span className="kbd">Ctrl/Cmd+O</span> — open a note
+            </b>
+            <p>Quick switcher. Type part of a file name and jump. This does not search file contents.</p>
           </li>
           <li>
-            <code>Ctrl/Cmd+F</code> — search (and replace) inside the current note
+            <b>
+              <span className="kbd">Ctrl/Cmd+Shift+F</span> — search the vault
+            </b>
+            <p>Fuzzy search across notes when you remember a phrase, not the title.</p>
           </li>
           <li>
-            <code>Ctrl/Cmd+P</code> — command palette
+            <b>
+              <span className="kbd">Ctrl/Cmd+F</span> — search this note
+            </b>
+            <p>Find and replace inside the file you already have open.</p>
           </li>
           <li>
-            <code>Ctrl/Cmd+O</code> — quick switcher
+            <b>
+              <span className="kbd">Ctrl/Cmd+P</span> — command palette
+            </b>
+            <p>
+              Run app commands (new note, graph, Spaces, theme). On this website the palette is{" "}
+              <code>Ctrl/Cmd+K</code>.
+            </p>
           </li>
         </ul>
         <p>
-          Bookmarks, daily notes, and the file explorer (with context menus for notes, folders, assets, and
-          canvases) cover the rest. Global shortcuts are listed under Keyboard.
+          Bookmarks, daily notes, and the file explorer (context menus for notes, folders, assets, and canvases)
+          cover the rest. The full shortcut list is on <Link to="/docs/shortcuts">Keyboard</Link>.
         </p>
       </>
     ),
@@ -282,24 +436,38 @@ npm run dev`}</pre>
     slug: "graph",
     title: "Graph",
     group: "Daily use",
-    summary: "Interactive graph plus a built-in AI view: suggested links, bridges, and idea islands.",
+    summary:
+      "The graph is your wiki links drawn as a map. A second AI view adds suggested links, bridges, and idea islands from embeddings that run on the machine.",
     body: (
       <>
         <p>
-          Open the graph with <code>Ctrl/Cmd+G</code>. Manual view uses your wiki links. AI view adds semantic
-          similarity from local embeddings — suggested links, bridges between clusters, and isolated idea
-          islands.
+          Press <code>Ctrl/Cmd+G</code>. Each node is a note. Each edge is a <code>[[wiki link]]</code> you
+          already wrote. Dense clusters are topics you have connected. Isolated dots are notes that never got a
+          link.
         </p>
+        <h2>Two views</h2>
+        <ul className="docs-points">
+          <li>
+            <b>Graph</b>
+            <p>Only the links you typed. Use this to see the structure you already have.</p>
+          </li>
+          <li>
+            <b>AI graph</b>
+            <p>
+              Semantic similarity on top of those links — suggested connections, bridges between clusters, and
+              idea islands. Embeddings run locally with <code>all-MiniLM-L6-v2</code>. No account.
+            </p>
+          </li>
+        </ul>
         <h2>What you can do there</h2>
         <ul>
           <li>Search, focus, filter, and center a node</li>
           <li>Tune physics and display</li>
           <li>Keep a persistent layout in local storage</li>
-          <li>D3 force layout in a worker, drawn with Canvas2D</li>
         </ul>
         <p>
-          The homepage animation is not a mock: it is laid out from real notes and <code>[[wiki links]]</code>{" "}
-          in <code>OO-Test-Vault</code>.
+          Layout is D3 in a worker, drawn with Canvas2D. The homepage graph is the same idea on the real{" "}
+          <code>OO-Test-Vault</code>, not a mock picture.
         </p>
       </>
     ),
@@ -308,19 +476,25 @@ npm run dev`}</pre>
     slug: "canvas",
     title: "Canvas",
     group: "Daily use",
-    summary: "Portable .canvas boards next to your notes — nodes, embeds, duplicate and save-as.",
+    summary:
+      "A canvas is a board saved as a .canvas file next to your notes. Nodes, edges, and embedded Markdown stay portable if you leave the app.",
     body: (
       <>
         <p>
-          Canvas files use the Obsidian <code>.canvas</code> format and live in the vault.{" "}
-          <code>Ctrl/Cmd+Shift+C</code> creates a new board. Open an existing <code>.canvas</code> file from
-          the explorer.
+          Use a canvas when a folder list is the wrong shape — a map of a project, a reading stack, a
+          comparison. It is still a file. OpenOnyx uses the Obsidian <code>.canvas</code> format, so the same
+          board can live in both apps.
         </p>
+        <h2>Create and open</h2>
+        <p>
+          <code>Ctrl/Cmd+Shift+C</code> creates a new board. Existing <code>.canvas</code> files show up in the
+          explorer like any other note. Duplicate and save-as are on the board.
+        </p>
+        <h2>What you can put on it</h2>
         <ul>
-          <li>Nodes, edges, and a toolbar</li>
-          <li>Embed Markdown notes on the board</li>
-          <li>Duplicate and save-as</li>
-          <li>Recent canvas tracking</li>
+          <li>Nodes and edges, with a toolbar</li>
+          <li>Embedded Markdown notes from the same vault</li>
+          <li>A recent-boards list so you can get back to the last map</li>
         </ul>
       </>
     ),
@@ -329,13 +503,18 @@ npm run dev`}</pre>
     slug: "spaces",
     title: "Spaces and AI",
     group: "Thinking layer",
-    summary: "Built-in RAG: local embeddings, cited answers, and optional inline rewrite — no extra plugin.",
+    summary:
+      "A Space lets you ask the vault a question and get an answer with citations. Embeddings run on the machine. Optional OpenAI or OpenRouter keys unlock rewrite, expand, and simplify.",
     body: (
       <>
         <p>
-          A Space is a queryable layer over your notes. OpenOnyx scans <code>.md</code> and <code>.canvas</code>{" "}
-          files, chunks text, and embeds the chunks in the browser with <code>@xenova/transformers</code> and
-          the <code>all-MiniLM-L6-v2</code> model (384 dimensions). No embedding API key is required.
+          Open Spaces from the ribbon or the command palette. Create a Space, let it index the folder, then
+          type a question in plain language. The answer should point back at the notes it used.
+        </p>
+        <p>
+          Under the hood, OpenOnyx scans <code>.md</code> and <code>.canvas</code> files, chunks the text, and
+          embeds the chunks in the app with <code>@xenova/transformers</code> and{" "}
+          <code>all-MiniLM-L6-v2</code> (384 dimensions). Local embeddings do not need an API key.
         </p>
         <h2>Visibility</h2>
         <ul>
@@ -368,13 +547,19 @@ npm run dev`}</pre>
     slug: "plugins",
     title: "Plugins",
     group: "Thinking layer",
-    summary: "Obsidian-compatible runtime (158/158 exports), marketplace, permission prompts, crash isolation.",
+    summary:
+      "Community plugins load through an Obsidian-compatible runtime: marketplace, permission prompts, and crash isolation. Compatibility is tested against the public API, not every private hook.",
     body: (
       <>
         <p>
-          OpenOnyx implements the public Obsidian plugin API against <code>obsidian@1.13.1</code>. A runtime
-          export audit checks 158 of 158 official exports. Community plugins load through a marketplace UI with
-          permission prompts and crash isolation.
+          You do not rewrite your plugin list from scratch. OpenOnyx implements the public Obsidian plugin API
+          against <code>obsidian@1.13.1</code>. A runtime audit checks 158 of 158 official exports. Plugins
+          install from a marketplace UI. They ask for permissions, and a crash in one plugin is isolated from
+          the rest of the app.
+        </p>
+        <p>
+          Plugins that depend on undocumented Obsidian internals can still need adapters. Compatibility is
+          against the public API, not every private hook.
         </p>
         <h2>Bundles exercised in CI-style tests</h2>
         <table>
@@ -393,10 +578,6 @@ npm run dev`}</pre>
             ))}
           </tbody>
         </table>
-        <p>
-          Plugins that depend on undocumented Obsidian internals can still need adapters. Compatibility is
-          against the public API, not every private hook.
-        </p>
       </>
     ),
   },
@@ -404,18 +585,31 @@ npm run dev`}</pre>
     slug: "themes",
     title: "Themes and wallpaper",
     group: "Thinking layer",
-    summary: "Dark, light, oceanic, custom themes, and a vault wallpaper with blur and opacity.",
+    summary:
+      "Dark, light, oceanic, and custom themes apply across the editor, graph, and settings. You can also set a vault wallpaper and keep type readable with blur and opacity.",
     body: (
       <>
         <p>
-          The chrome is built for long sessions: quiet surfaces, Inter, restrained contrast. Themes apply across
-          editor, graph, settings, and plugin views.
+          Open Appearance from the command palette or the workspace chrome. Themes are for long sessions: quiet
+          surfaces, Inter, restrained contrast. A theme change hits the editor, the graph, settings, and
+          plugin views together.
         </p>
-        <ul>
-          <li>Dark, light, oceanic, and custom themes</li>
-          <li>Upload a wallpaper image</li>
-          <li>Blur and opacity controls so type stays readable</li>
-          <li>Translucent editor and sidebar panels</li>
+        <ul className="docs-points">
+          <li>
+            <b>Built-in themes</b>
+            <p>Dark, light, and oceanic. Custom themes can be added on top.</p>
+          </li>
+          <li>
+            <b>Wallpaper</b>
+            <p>
+              Upload an image behind the workspace. Blur and opacity sliders keep the Markdown readable. The
+              live editor on the homepage has the same control.
+            </p>
+          </li>
+          <li>
+            <b>Translucent panels</b>
+            <p>Editor and sidebar can sit on the wallpaper without washing out the type.</p>
+          </li>
         </ul>
       </>
     ),
@@ -424,19 +618,21 @@ npm run dev`}</pre>
     slug: "sync",
     title: "Sync and collaboration",
     group: "Optional cloud",
-    summary: "Optional Supabase sync. Live multiplayer is in the app but currently under maintenance.",
+    summary:
+      "Writing never needs a server. If you want Spaces sync, you bring your own Supabase project. Live multiplayer editing is in the app but currently shows a maintenance notice.",
     body: (
       <>
         <p>
-          Cloud features use your own Supabase project. Enable the <code>vector</code> extension, run{" "}
+          Skip this page if you only want a local folder. Cloud is a switch, not a login wall. When you do turn
+          it on, you use your own Supabase project: enable the <code>vector</code> extension, run{" "}
           <code>supabase/schema.sql</code>, and paste the project URL plus anon key into settings (or{" "}
           <code>.env.local</code>).
         </p>
-        <div className="callout">
+        <Caution>
           The collaboration panel currently shows a maintenance notice: real-time multiplayer editing has
           known issues and is being fixed. Do not treat live co-editing as ready. Offline Spaces sync is still
           in the tree.
-        </div>
+        </Caution>
         <h2>How sync behaves</h2>
         <ul>
           <li>Mutations go through a durable IndexedDB queue and are retried when you are back online.</li>
@@ -458,16 +654,42 @@ npm run dev`}</pre>
     slug: "privacy",
     title: "Privacy",
     group: "Optional cloud",
-    summary: "Offline by default. No product telemetry. Cloud and remote LLMs only if you turn them on.",
+    summary:
+      "Editing, search, graph, and local Spaces work offline. There is no product telemetry. Cloud and remote models only see what you send after you turn them on.",
     body: (
       <>
-        <ul>
-          <li>Core editing, search, graph, local embeddings, and local Spaces work offline.</li>
-          <li>Notes are files in the vault you chose.</li>
-          <li>Indexes, embeddings, and caches stay on device unless you enable cloud-backed features.</li>
-          <li>The renderer is context-isolated; filesystem access goes through a preload IPC bridge.</li>
-          <li>Supabase is optional. Remote LLMs receive only the prompt and retrieved context you asked for.</li>
-          <li>The project does not include product analytics or telemetry.</li>
+        <p>
+          Default is local. You can use the app on a plane. Anything that leaves the machine is something you
+          switched on.
+        </p>
+        <ul className="docs-points">
+          <li>
+            <b>Offline first</b>
+            <p>Core editing, search, graph, local embeddings, and local Spaces do not need a network.</p>
+          </li>
+          <li>
+            <b>Files stay files</b>
+            <p>Notes live in the folder you chose. The app is not a second copy of your vault.</p>
+          </li>
+          <li>
+            <b>Caches stay on the device</b>
+            <p>Indexes and embeddings stay local unless you enable a cloud-backed Space.</p>
+          </li>
+          <li>
+            <b>Isolated renderer</b>
+            <p>The window is context-isolated. Filesystem access goes through a preload IPC bridge.</p>
+          </li>
+          <li>
+            <b>You choose the cloud</b>
+            <p>
+              Supabase is optional. A remote LLM receives only the prompt and the retrieved chunks for that
+              question.
+            </p>
+          </li>
+          <li>
+            <b>No product telemetry</b>
+            <p>The desktop does not phone home with usage analytics.</p>
+          </li>
         </ul>
       </>
     ),
@@ -476,12 +698,14 @@ npm run dev`}</pre>
     slug: "shortcuts",
     title: "Keyboard",
     group: "Reference",
-    summary: "The shortcuts wired in the app today.",
+    summary:
+      "These are the shortcuts wired in the desktop today. The website palette is Ctrl/Cmd+K; the app palette is Ctrl/Cmd+P.",
     body: (
       <>
         <p>
-          These are the shortcuts wired in the desktop renderer today. The website command palette uses{" "}
-          <code>Ctrl/Cmd+K</code>; the app palette is <code>Ctrl/Cmd+P</code>.
+          Memorize four: <code>Ctrl/Cmd+O</code> to open a note, <code>Ctrl/Cmd+P</code> for commands,{" "}
+          <code>Ctrl/Cmd+G</code> for the graph, <code>Ctrl/Cmd+S</code> to save. The rest is below. This
+          website’s command palette uses <code>Ctrl/Cmd+K</code> so it does not fight the browser.
         </p>
         <table>
           <thead>
@@ -508,9 +732,14 @@ npm run dev`}</pre>
     slug: "develop",
     title: "Develop",
     group: "Reference",
-    summary: "Commands, architecture, and how the processes talk.",
+    summary:
+      "Clone the repo, run the desktop against Vite, and see how the renderer talks to the filesystem through preload IPC. Node.js 22 or newer.",
     body: (
       <>
+        <p>
+          This page is for people changing the app. Day-to-day writing does not need it. Requires Node.js 22 or
+          newer.
+        </p>
         <table>
           <thead>
             <tr>

--- a/website/src/pages/Docs.tsx
+++ b/website/src/pages/Docs.tsx
@@ -124,14 +124,40 @@ export function Docs() {
 
       <div className="docs-main">
         <article className="docs-body" key={page.slug}>
-          <div className="kicker">{page.group}</div>
-          <h1>{page.title}</h1>
-          <p className="docs-lede">{page.summary}</p>
+          <nav className="docs-crumbs" aria-label="Breadcrumb">
+            <Link to="/docs/start">Documentation</Link>
+            {page.slug !== "start" && (
+              <>
+                <span aria-hidden>/</span>
+                <span>{page.group}</span>
+                <span aria-hidden>/</span>
+                <span>{page.title}</span>
+              </>
+            )}
+          </nav>
+          <header className="docs-hero">
+            <h1>{page.title}</h1>
+            <p className="docs-lede">{page.summary}</p>
+          </header>
           {withHeadingIds(page.body)}
-          <div className="doc-nav">
-            {prev ? <Link to={`/docs/${prev.slug}`}>← {prev.title}</Link> : <span />}
-            {next ? <Link to={`/docs/${next.slug}`}>{next.title} →</Link> : <span />}
-          </div>
+          <nav className="doc-nav" aria-label="Page turn">
+            {prev ? (
+              <Link to={`/docs/${prev.slug}`}>
+                <span>Previous</span>
+                {prev.title}
+              </Link>
+            ) : (
+              <span />
+            )}
+            {next ? (
+              <Link to={`/docs/${next.slug}`}>
+                <span>Next</span>
+                {next.title}
+              </Link>
+            ) : (
+              <span />
+            )}
+          </nav>
         </article>
 
         <aside className="docs-rail">
@@ -146,10 +172,11 @@ export function Docs() {
             </div>
           )}
           <div>
-            <h4>Continue</h4>
-            {next && <Link to={`/docs/${next.slug}`}>{next.title}</Link>}
-            {prev && <Link to={`/docs/${prev.slug}`}>{prev.title}</Link>}
-            <Link to="/download">Download</Link>
+            <h4>Feedback</h4>
+            <a href={`${PRODUCT.repo}/issues/new`} target="_blank" rel="noreferrer">
+              Open an issue
+            </a>
+            <Link to="/download">Download v{PRODUCT.version}</Link>
             <a href={PRODUCT.repo} target="_blank" rel="noreferrer">
               Source on GitHub
             </a>

--- a/website/src/styles/global.css
+++ b/website/src/styles/global.css
@@ -539,122 +539,275 @@ img, video { max-width: 100%; display: block; }
 .footer a { border-bottom: 1px solid transparent; }
 .footer a:hover { color: var(--text); border-bottom-color: var(--line-strong); }
 
-/* —— docs —— */
+/* —— docs (documentation paper, independent of site theme) —— */
 .docs {
+  --docs-paper: #ffffff;
+  --docs-side: #f4f6f8;
+  --docs-ink: #1b1f23;
+  --docs-copy: #3b434b;
+  --docs-faint: #6e7781;
+  --docs-line: #d8dee4;
+  --docs-link: #0969da;
+  --docs-note: #ddf4ff;
+  --docs-note-edge: #0969da;
+  --docs-caution: #fff8c5;
+  --docs-caution-edge: #9a6700;
+  --docs-code: #f3f4f6;
   display: grid;
-  grid-template-columns: 248px minmax(0, 1fr);
+  grid-template-columns: 260px minmax(0, 1fr);
   min-height: calc(100vh - var(--header));
-  background: var(--bg);
+  background: var(--docs-paper);
+  color: var(--docs-ink);
+}
+html[data-theme="dark"] .docs {
+  --docs-paper: #16161c;
+  --docs-side: #121218;
+  --docs-ink: #ececec;
+  --docs-copy: #c4c4cc;
+  --docs-faint: #8b8b94;
+  --docs-line: rgba(255, 255, 255, 0.1);
+  --docs-link: #79b8ff;
+  --docs-note: #182536;
+  --docs-note-edge: #58a6ff;
+  --docs-caution: #2a2414;
+  --docs-caution-edge: #d4a017;
+  --docs-code: #1e1e26;
 }
 .docs-side {
-  border-right: 1px solid var(--line);
-  padding: 28px 18px 56px 22px;
+  border-right: 1px solid var(--docs-line);
+  padding: 20px 14px 48px 16px;
   position: sticky;
   top: var(--header);
   height: calc(100vh - var(--header));
   overflow: auto;
-  background: var(--bg);
+  background: var(--docs-side);
 }
 .docs-side h4,
 .docs-rail h4 {
-  margin: 22px 10px 8px;
+  margin: 20px 10px 6px;
   font-size: 11px;
-  letter-spacing: 0.08em;
+  letter-spacing: 0.06em;
   text-transform: uppercase;
-  color: var(--faint);
-  font-weight: 600;
+  color: var(--docs-faint);
+  font-weight: 650;
 }
-.docs-side h4:first-of-type { margin-top: 14px; }
+.docs-side h4:first-of-type { margin-top: 16px; }
 .docs-side a,
 .docs-rail a {
   display: block;
-  padding: 6px 10px;
+  padding: 5px 10px;
   border-radius: 0;
-  color: var(--muted);
-  font-size: 13px;
+  color: var(--docs-copy);
+  font-size: 14px;
   line-height: 1.4;
-  border-left: 1px solid transparent;
-  transition: color 0.18s ease, border-color 0.18s ease, background 0.18s ease;
+  border-left: 2px solid transparent;
 }
 .docs-side a.active,
 .docs-rail a.active {
-  color: var(--text);
-  border-left-color: var(--text);
+  color: var(--docs-ink);
+  border-left-color: var(--docs-link);
+  font-weight: 600;
   background: transparent;
 }
 .docs-side a:hover,
 .docs-rail a:hover {
-  color: var(--text);
+  color: var(--docs-link);
   background: transparent;
+}
+.docs-filter {
+  width: 100%;
+  margin: 0 0 4px;
+  height: 34px;
+  padding: 0 10px;
+  border: 1px solid var(--docs-line);
+  border-radius: 6px;
+  background: var(--docs-paper);
+  color: var(--docs-ink);
+  font-size: 13px;
+  outline: none;
+}
+.docs-filter:focus {
+  border-color: var(--docs-link);
 }
 .docs-main {
   display: grid;
-  grid-template-columns: minmax(0, 1fr) 208px;
+  grid-template-columns: minmax(0, 1fr) 220px;
   gap: 0;
   align-items: start;
   padding: 0;
+  background: var(--docs-paper);
 }
 .docs-body {
   max-width: none;
   min-width: 0;
-  overflow-wrap: anywhere;
-  padding: 44px 48px 88px;
-  animation: page-in 0.28s ease;
+  overflow-wrap: break-word;
+  padding: 28px 48px 80px;
+  margin: 0;
+  min-height: calc(100vh - var(--header));
+  background: var(--docs-paper);
+  color: var(--docs-ink);
+  animation: page-in 0.2s ease;
+}
+.docs-body > *,
+.docs-hero,
+.docs-crumbs {
+  max-width: 46rem;
+}
+.docs-body .compare-wrap,
+.docs-body table {
+  max-width: 52rem;
+}
+.docs-crumbs {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px 8px;
+  align-items: center;
+  font-size: 13px;
+  color: var(--docs-faint);
+  margin: 0 0 18px;
+}
+.docs-crumbs a { color: var(--docs-link); }
+.docs-hero {
+  padding-bottom: 0;
+  margin-bottom: 8px;
+  border-bottom: 0;
 }
 .docs-body h1 {
-  font-size: clamp(28px, 4vw, 36px);
-  font-weight: 600;
-  letter-spacing: -0.035em;
-  margin: 6px 0 10px;
-  line-height: 1.15;
+  font-size: clamp(30px, 4vw, 38px);
+  font-weight: 700;
+  letter-spacing: -0.03em;
+  margin: 0 0 12px;
+  line-height: 1.18;
+  color: var(--docs-ink);
 }
 .docs-lede {
-  margin: 0 0 28px;
-  color: var(--muted);
-  font-size: 17px;
+  margin: 0 0 8px;
+  color: var(--docs-copy);
+  font-size: 18px;
   line-height: 1.55;
+  max-width: 46rem;
 }
 .docs-body h2 {
-  font-size: 18px;
-  font-weight: 600;
-  margin: 32px 0 10px;
+  font-size: 22px;
+  font-weight: 650;
+  margin: 36px 0 12px;
+  padding-bottom: 6px;
+  border-bottom: 1px solid var(--docs-line);
   letter-spacing: -0.02em;
+  color: var(--docs-ink);
   scroll-margin-top: calc(var(--header) + 16px);
 }
-.docs-body p { color: var(--prose); margin: 0 0 14px; font-size: 15px; line-height: 1.7; }
-.docs-body a { color: var(--link); }
-.docs-body ul, .docs-body ol { margin: 0 0 16px; padding-left: 20px; }
-.docs-body li { color: var(--prose); margin: 6px 0; font-size: 15px; line-height: 1.6; }
-.docs-body code, .kbd {
+.docs-body h3 {
+  font-size: 16px;
+  font-weight: 650;
+  margin: 22px 0 8px;
+  letter-spacing: -0.015em;
+  color: var(--docs-ink);
+}
+.docs-body p { color: var(--docs-copy); margin: 0 0 14px; font-size: 16px; line-height: 1.7; }
+.docs-steps {
+  margin: 0 0 20px;
+  padding-left: 1.35em;
+}
+.docs-steps li { margin: 10px 0; color: var(--docs-copy); }
+.docs-steps b { display: block; color: var(--docs-ink); font-weight: 650; margin-bottom: 2px; }
+.docs-steps p { margin: 0; }
+.docs-hub { margin: 28px 0 8px; }
+.docs-hub h2 { margin-top: 32px; }
+.docs-hub ul {
+  list-style: none;
+  margin: 8px 0 8px;
+  padding: 0;
+}
+.docs-hub li {
+  margin: 0;
+  padding: 7px 0;
+  border-top: 1px solid var(--docs-line);
+  color: var(--docs-copy);
+  font-size: 15px;
+  line-height: 1.5;
+}
+.docs-hub li:last-child { border-bottom: 1px solid var(--docs-line); }
+.docs-hub a { font-weight: 600; }
+.docs-hub-more { margin: 10px 0 0; font-weight: 600; }
+.docs-points { margin: 0 0 20px; padding: 0; list-style: none; }
+.docs-points li {
+  padding: 12px 0;
+  border-top: 1px solid var(--docs-line);
+  margin: 0;
+}
+.docs-points li:last-child { border-bottom: 1px solid var(--docs-line); }
+.docs-points b { display: block; color: var(--docs-ink); margin-bottom: 4px; }
+.docs-points p { margin: 0; }
+.docs-note {
+  border-left: 4px solid var(--docs-note-edge);
+  background: var(--docs-note);
+  padding: 12px 14px;
+  margin: 0 0 20px;
+  color: var(--docs-ink);
+  font-size: 15px;
+  line-height: 1.55;
+}
+.docs-note.is-caution {
+  border-left-color: var(--docs-caution-edge);
+  background: var(--docs-caution);
+}
+.docs-note strong {
+  display: block;
+  margin-bottom: 4px;
+  font-size: 13px;
+  letter-spacing: 0.02em;
+  text-transform: uppercase;
+}
+.docs-note p { margin: 0; color: var(--docs-ink); }
+.docs-body a { color: var(--docs-link); }
+.docs-body ul, .docs-body ol { margin: 0 0 16px; padding-left: 22px; }
+.docs-body li { color: var(--docs-copy); margin: 6px 0; font-size: 16px; line-height: 1.6; }
+.docs-body code, .docs .kbd {
   font-family: var(--mono);
   font-size: 0.86em;
-  background: var(--bg-2);
-  border: 1px solid var(--line);
+  background: var(--docs-code);
+  border: 1px solid var(--docs-line);
   border-radius: 4px;
-  padding: 0.1em 0.4em;
+  padding: 0.08em 0.38em;
+  color: var(--docs-ink);
+  overflow-wrap: normal;
+  word-break: normal;
 }
 .docs-body pre,
 .card pre {
-  background: var(--bg-2);
-  border: 1px solid var(--line);
-  border-radius: 8px;
+  background: var(--docs-code);
+  border: 1px solid var(--docs-line);
+  border-radius: 6px;
   padding: 14px 16px;
   overflow-x: auto;
   max-width: 100%;
   font-family: var(--mono);
   font-size: 13px;
-  color: var(--text);
+  color: var(--docs-ink);
   margin: 0 0 16px;
   white-space: pre;
 }
-.docs-body table { width: 100%; border-collapse: collapse; font-size: 14px; margin: 8px 0 20px; }
+.docs-body table { width: 100%; border-collapse: collapse; font-size: 14px; margin: 8px 0 20px; background: var(--docs-paper); }
 .docs-body th, .docs-body td {
-  border-top: 1px solid var(--line);
+  border-top: 1px solid var(--docs-line);
   padding: 10px 8px;
   text-align: left;
   vertical-align: top;
+  color: var(--docs-copy);
 }
-.docs-body th { color: var(--muted); font-weight: 500; }
+.docs-body th { color: var(--docs-faint); font-weight: 600; }
+.docs-body .compare-wrap {
+  background: var(--docs-paper);
+  border-color: var(--docs-line);
+}
+.docs-body .compare-table th,
+.docs-body .compare-table td { color: var(--docs-copy); }
+.docs-body .compare-table td:nth-child(2),
+.docs-body .compare-table thead th:nth-child(2) {
+  background: var(--docs-side);
+  color: var(--docs-ink);
+}
 .callout {
   border: 1px solid var(--line);
   background: var(--bg-2);
@@ -666,24 +819,42 @@ img, video { max-width: 100%; display: block; }
   margin: 0 0 20px;
 }
 .doc-nav {
-  display: flex;
-  justify-content: space-between;
+  display: grid;
+  grid-template-columns: 1fr 1fr;
   gap: 12px;
-  margin-top: 40px;
-  border-top: 1px solid var(--line);
-  padding-top: 18px;
+  margin-top: 48px;
+  border-top: 1px solid var(--docs-line);
+  padding-top: 20px;
+  max-width: 46rem;
 }
-.doc-nav a { color: var(--muted); font-size: 14px; }
-.doc-nav a:hover { color: var(--text); }
+.doc-nav a {
+  display: block;
+  padding: 14px 16px;
+  border: 1px solid var(--docs-line);
+  border-radius: 6px;
+  color: var(--docs-ink);
+  font-size: 16px;
+  font-weight: 600;
+  line-height: 1.35;
+}
+.doc-nav a span {
+  display: block;
+  font-size: 12px;
+  font-weight: 500;
+  color: var(--docs-faint);
+  margin-bottom: 4px;
+}
+.doc-nav a:hover { border-color: var(--docs-link); color: var(--docs-link); }
 .docs-rail {
   position: sticky;
   top: var(--header);
-  padding: 48px 20px 56px 22px;
-  border-left: 1px solid var(--line);
+  padding: 28px 18px 56px 16px;
+  border-left: 1px solid var(--docs-line);
   min-height: calc(100vh - var(--header));
+  background: var(--docs-paper);
 }
 .docs-rail h4 { margin-top: 0; }
-.docs-rail > div + div { margin-top: 28px; padding-top: 22px; border-top: 1px solid var(--line); }
+.docs-rail > div + div { margin-top: 24px; padding-top: 18px; border-top: 1px solid var(--docs-line); }
 
 /* —— download —— */
 .download-grid {
@@ -716,7 +887,8 @@ img, video { max-width: 100%; display: block; }
 
 @media (max-width: 1100px) {
   .docs-main { grid-template-columns: 1fr; }
-  .docs-body { padding: 36px 28px 64px; }
+  .docs-body { padding: 32px 28px 64px; }
+  .docs-next { grid-template-columns: 1fr; }
   .docs-rail {
     position: static;
     display: grid;
@@ -725,8 +897,9 @@ img, video { max-width: 100%; display: block; }
     min-height: 0;
     padding: 24px 28px 48px;
     border-left: 0;
-    border-top: 1px solid var(--line);
+    border-top: 1px solid var(--docs-line);
   }
+  .doc-nav { grid-template-columns: 1fr; }
 }
 
 @media (max-width: 980px) {
@@ -754,7 +927,7 @@ img, video { max-width: 100%; display: block; }
     top: 0;
     height: auto;
     border-right: 0;
-    border-bottom: 1px solid var(--line);
+    border-bottom: 1px solid var(--docs-line);
     padding: 10px var(--pad) 12px;
     display: flex;
     flex-wrap: nowrap;
@@ -783,7 +956,9 @@ img, video { max-width: 100%; display: block; }
   }
   .docs-main { padding: 20px var(--pad) 56px; }
   .docs-rail { grid-template-columns: 1fr; }
-  .docs-body { padding: 0; }
+  .docs-body { padding: 8px 0 48px; background: var(--docs-paper); }
+  .docs { background: var(--docs-paper); }
+  .doc-nav { grid-template-columns: 1fr; }
   h1, h2 { overflow-wrap: anywhere; }
   .docs-body pre,
   .card pre { white-space: pre-wrap; word-break: break-word; }
@@ -1181,23 +1356,6 @@ img, video { max-width: 100%; display: block; }
 }
 @media (max-width: 760px) {
   .inventory-grid { grid-template-columns: 1fr; }
-}
-
-.docs-filter {
-  width: 100%;
-  margin: 0 0 4px;
-  height: 34px;
-  padding: 0 10px;
-  border: 1px solid var(--line);
-  border-radius: 6px;
-  background: transparent;
-  font-size: 13px;
-  outline: none;
-  transition: border-color 0.16s ease, background 0.16s ease;
-}
-.docs-filter:focus {
-  border-color: var(--line-strong);
-  background: var(--bg-2);
 }
 
 /* command palette */

--- a/website/src/styles/global.css
+++ b/website/src/styles/global.css
@@ -13,7 +13,7 @@
   --max: 1080px;
   --wide: 1240px;
   --page: 1320px;
-  --header: 56px;
+  --header: 60px;
   --pad: clamp(16px, 4vw, 32px);
   --prose: #c2c2ca;
   --header-bg: rgba(15, 15, 20, 0.92);
@@ -116,27 +116,27 @@ img, video { max-width: 100%; display: block; }
   align-items: center;
   gap: 10px;
   font-weight: 600;
-  font-size: 15px;
+  font-size: 16px;
   letter-spacing: -0.03em;
   flex-shrink: 0;
 }
 .brand img {
-  width: 26px;
-  height: 26px;
+  width: 28px;
+  height: 28px;
   filter: invert(var(--invert));
 }
 .nav-links {
   display: flex;
   align-items: center;
-  gap: 20px;
+  gap: 22px;
 }
 .nav-links a,
 .mobile-nav a {
   position: relative;
   color: var(--muted);
-  font-size: 13px;
+  font-size: 14px;
   letter-spacing: -0.01em;
-  padding: 2px 0;
+  padding: 4px 0;
   transition: color 0.15s ease;
 }
 .nav-links a::after,
@@ -167,9 +167,9 @@ img, video { max-width: 100%; display: block; }
 .header-meta {
   display: flex;
   align-items: center;
-  gap: 6px;
+  gap: 8px;
   flex-shrink: 0;
-  height: 32px;
+  height: 36px;
 }
 .meta-chip,
 .theme-toggle {
@@ -177,21 +177,21 @@ img, video { max-width: 100%; display: block; }
   align-items: center;
   justify-content: center;
   gap: 6px;
-  height: 32px;
-  padding: 0 10px;
+  height: 36px;
+  padding: 0 12px;
   border: 1px solid var(--line);
-  border-radius: 6px;
+  border-radius: 7px;
   color: var(--muted);
   background: var(--chip);
   font-family: var(--mono);
-  font-size: 11px;
+  font-size: 12px;
   letter-spacing: 0.01em;
   cursor: pointer;
   overflow: hidden;
   transition: color 0.16s ease, border-color 0.16s ease, background 0.16s ease;
 }
 .theme-toggle {
-  width: 32px;
+  width: 36px;
   padding: 0;
 }
 .theme-toggle svg {
@@ -210,23 +210,23 @@ img, video { max-width: 100%; display: block; }
 }
 .nav-toggle {
   display: none;
-  width: 28px;
-  height: 28px;
+  width: 36px;
+  height: 36px;
   position: relative;
   cursor: pointer;
 }
 .nav-toggle span {
   position: absolute;
-  left: 5px;
-  right: 5px;
+  left: 8px;
+  right: 8px;
   height: 1.5px;
   background: var(--text);
   transition: transform 0.2s ease, top 0.2s ease;
 }
-.nav-toggle span:nth-of-type(2) { top: 9px; }
-.nav-toggle span:nth-of-type(3) { top: 17px; }
-.header.is-open .nav-toggle span:nth-of-type(2) { top: 13px; transform: rotate(45deg); }
-.header.is-open .nav-toggle span:nth-of-type(3) { top: 13px; transform: rotate(-45deg); }
+.nav-toggle span:nth-of-type(2) { top: 12px; }
+.nav-toggle span:nth-of-type(3) { top: 22px; }
+.header.is-open .nav-toggle span:nth-of-type(2) { top: 17px; transform: rotate(45deg); }
+.header.is-open .nav-toggle span:nth-of-type(3) { top: 17px; transform: rotate(-45deg); }
 .mobile-nav {
   display: none;
   flex-direction: column;
@@ -917,9 +917,21 @@ html[data-theme="dark"] .docs {
   .section h2 { max-width: none; }
 }
 
+@media (max-width: 900px) {
+  .header-left { gap: 18px; }
+  .nav-links { gap: 16px; }
+}
 @media (max-width: 760px) {
   .nav-links { display: none; }
   .nav-toggle { display: block; }
+}
+@media (max-width: 560px) {
+  .meta-chip-version { display: none; }
+}
+@media (max-width: 420px) {
+  .meta-chip-palette { display: none; }
+}
+@media (max-width: 760px) {
   .mobile-nav:not([hidden]) { display: flex; }
   .principles, .gallery, .docs, .download-grid, .inventory-grid { grid-template-columns: 1fr; }
   .docs-side {
@@ -974,6 +986,7 @@ html[data-theme="dark"] .docs {
 
 @media (max-width: 420px) {
   .hero-actions .btn { flex: 1; }
+  .meta-chip-palette { display: none; }
 }
 
 @media (prefers-reduced-motion: reduce) {
@@ -1049,7 +1062,7 @@ html[data-theme="dark"] .docs {
 .story-theater {
   display: grid;
   isolation: isolate;
-  margin-top: 56px;
+  margin-top: 28px;
 }
 .story-pin,
 .story-track {
@@ -1063,15 +1076,20 @@ html[data-theme="dark"] .docs {
   align-self: start;
   height: calc(100vh - var(--header));
   display: grid;
-  grid-template-columns: minmax(0, 0.86fr) minmax(0, 1.14fr);
-  gap: 48px;
+  grid-template-columns: minmax(250px, 34%) minmax(0, 66%);
+  gap: 36px;
   align-items: center;
+  padding: 20px 0 24px;
   background: var(--bg);
 }
 .story-copy {
+  position: static;
   display: grid;
   align-items: center;
   min-width: 0;
+  width: auto;
+  padding: 0;
+  background: none;
 }
 .story-copy-card {
   grid-area: 1 / 1;
@@ -1095,22 +1113,22 @@ html[data-theme="dark"] .docs {
 .story-copy-card h2,
 .story-mobile h2 {
   margin: 8px 0 12px;
-  font-size: clamp(22px, 3vw, 32px);
+  font-size: clamp(24px, 3vw, 34px);
   font-weight: 550;
   letter-spacing: -0.03em;
-  max-width: 16ch;
+  max-width: 15ch;
 }
 .story-copy-card p,
 .story-mobile p {
   margin: 0;
   color: var(--muted);
-  max-width: 44ch;
-  font-size: 14px;
+  max-width: 40ch;
+  font-size: 15px;
   line-height: 1.6;
 }
 .story-chapter {
-  height: 42vh;
-  min-height: 260px;
+  height: 30vh;
+  min-height: 200px;
 }
 .story-mobile { display: none; }
 .story-chapter-shot { display: none; }
@@ -1122,15 +1140,22 @@ html[data-theme="dark"] .docs {
 .story-frame {
   width: 100%;
   min-width: 0;
+  min-height: 0;
+  height: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
 }
 .story-frame-inner {
   position: relative;
   width: 100%;
+  height: auto;
+  max-height: 100%;
+  aspect-ratio: 16 / 10;
   overflow: hidden;
   border: 1px solid var(--line);
-  border-radius: 10px;
+  border-radius: 12px;
   background: #0b0b10;
-  aspect-ratio: 16 / 10;
   box-shadow: 0 18px 48px rgba(0, 0, 0, 0.22);
 }
 .story-frame-inner img {


### PR DESCRIPTION
## Why

The docs were a dark, one-line marketing page. A first-time reader could not tell what OpenOnyx is or what to do next. This rebuilds `/docs` as a real documentation site.

## What

- **Hub home** (`/docs/start`): Get going, Daily use, Thinking layer, Optional cloud, Reference — each with a short description and links, same shape as kubernetes.io/docs.
- **Page chrome:** breadcrumbs, “On this page”, Previous/Next, Feedback.
- **Notes:** labeled Note / Caution callouts instead of flat gray boxes.
- **Copy:** every page explains what the thing is, how to use it, and what it is not. Facts stay from the real product (v1.0.4, no shipped mobile, live collab under maintenance).
- **Theme:** light is paper-white; dark is the same layout. The site theme toggle restyles the whole docs page, not just the header.

## Files

- `website/src/data/docs.tsx`
- `website/src/pages/Docs.tsx`
- `website/src/styles/global.css`

From fork `rishi-jat/OpenOnyx` branch `feat/docs-production`.