### PR TITLE
Show recent vaults on Welcome Screen with one-click open

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2551,6 +2551,7 @@ export default function App() {
     handleOpenVault,
     handleCreateVault,
     handleSwitchVault,
+    handleCloseVault,
     handleWelcomeVaultAction,
     handleCopyVaultId,
     handleRenameVault,
@@ -5247,9 +5248,13 @@ export default function App() {
               <div className="vault-entry-layer vault-entry-layer-welcome">
                 <WelcomeScreen
                   onOpenVault={handleWelcomeVaultAction}
+                  currentVaultPath={vaultPath}
+                  previouslyOpenedVaults={previouslyOpenedVaults}
+                  onSwitchVault={handleSwitchVault}
+                  onRemoveVaultFromList={handleRemoveVaultFromList}
                   transitionPhase={vaultEntryTransitionPhase}
                   theme={theme}
-                  settings={settings}
+                  settings={settings} 
                 />
               </div>
 
@@ -5262,6 +5267,10 @@ export default function App() {
           ) : !vaultPath ? (
             <WelcomeScreen
               onOpenVault={handleWelcomeVaultAction}
+              currentVaultPath={vaultPath}
+              previouslyOpenedVaults={previouslyOpenedVaults}
+              onSwitchVault={handleSwitchVault}
+              onRemoveVaultFromList={handleRemoveVaultFromList}
               transitionPhase="idle"
               theme={theme}
               settings={settings}
@@ -5685,6 +5694,7 @@ export default function App() {
           onCreateVault={handleCreateVault}
           onOpenVault={handleOpenVault}
           onSwitchVault={handleSwitchVault}
+          onCloseVault={handleCloseVault}
           onRevealVault={(path) => {
             void api.showItemInFolder(path);
           }}

--- a/src/components/settings/VaultManager.tsx
+++ b/src/components/settings/VaultManager.tsx
@@ -11,7 +11,7 @@ import {
   X,
 } from "lucide-react";
 import { Theme } from "../../types";
-import { isDarkTheme } from "../../utils/helpers";
+import { isDarkTheme, vaultName  } from "../../utils/helpers";
 import type { AppSettings } from "./SettingsPage";
 
 interface VaultManagerProps {
@@ -22,16 +22,13 @@ interface VaultManagerProps {
   onCreateVault: () => Promise<boolean>;
   onOpenVault: () => Promise<boolean>;
   onSwitchVault: (path: string) => Promise<boolean>;
+  onCloseVault?: () => Promise<void>;
   onRevealVault?: (path: string) => void;
   onCopyVaultId?: (path: string) => void;
   onRenameVault?: (path: string) => Promise<void>;
   onMoveVault?: (path: string) => Promise<void>;
   onRemoveVaultFromList?: (path: string) => Promise<void>;
   onClose: () => void;
-}
-
-function vaultName(path: string): string {
-  return path.split(/[/\\]/).filter(Boolean).pop() || path;
 }
 
 function uniqueVaults(paths: Array<string | null | undefined>): string[] {
@@ -53,6 +50,7 @@ export function VaultManager({
   onCreateVault,
   onOpenVault,
   onSwitchVault,
+  onCloseVault,
   onRevealVault,
   onCopyVaultId,
   onRenameVault,
@@ -147,10 +145,13 @@ export function VaultManager({
                         </span>
                       </span>
                       {isCurrent ? (
-                        <Check
-                          size={15}
-                          className="mt-1 shrink-0 text-[var(--accent-primary)]"
-                        />
+                        // <Check
+                        //   size={15}
+                        //   className="mt-1 shrink-0 text-[var(--accent-primary)]"
+                        // />
+                        <span className="mt-1 flex shrink-0 items-center gap-2">
+                          <Check size={15} className="text-[var(--accent-primary)]" />
+                        </span>
                       ) : null}
                     </button>
                     <button
@@ -218,6 +219,19 @@ export function VaultManager({
               })
             )}
           </div>
+          {currentVaultPath && onCloseVault ? (
+              <button
+                type="button"
+                className="mt-3 flex w-full cursor-pointer items-center justify-center gap-2 rounded-md border border-[var(--border-subtle)] bg-transparent px-3 py-2 text-[13px] text-[var(--text-secondary)] transition-colors hover:bg-[var(--bg-hover)] hover:text-[var(--text-primary)] disabled:cursor-not-allowed disabled:opacity-60"
+                disabled={!!busyAction}
+                onClick={() => void runAction("close-vault", async () => {
+                  await onCloseVault();
+                  return true;
+                })}
+              >
+                {busyAction === "close-vault" ? "Closing..." : "Close current vault"}
+              </button>
+            ) : null}
         </aside>
 
         <section className="relative flex min-w-0 flex-1 flex-col bg-[var(--bg-primary)]">

--- a/src/components/settings/VaultManager.tsx
+++ b/src/components/settings/VaultManager.tsx
@@ -145,10 +145,6 @@ export function VaultManager({
                         </span>
                       </span>
                       {isCurrent ? (
-                        // <Check
-                        //   size={15}
-                        //   className="mt-1 shrink-0 text-[var(--accent-primary)]"
-                        // />
                         <span className="mt-1 flex shrink-0 items-center gap-2">
                           <Check size={15} className="text-[var(--accent-primary)]" />
                         </span>

--- a/src/components/settings/WelcomeScreen.tsx
+++ b/src/components/settings/WelcomeScreen.tsx
@@ -6,16 +6,21 @@
  */
 
 import React, { useEffect, useRef, useState } from "react";
-import { FolderOpen, Plus, Network } from "lucide-react";
+import { FolderOpen, Plus, X } from "lucide-react";
 import { Theme } from "../../types";
-import { isDarkTheme } from "../../utils/helpers";
+import { isDarkTheme, vaultName } from "../../utils/helpers";
 import type { AppSettings } from "./SettingsPage";
 
 export type VaultEntryAction = "open" | "create";
 export type VaultEntryTransitionPhase = "idle" | "transitioning" | "entered";
 
+
 interface WelcomeScreenProps {
   onOpenVault: (action: VaultEntryAction) => void;
+  currentVaultPath?: string | null;
+  previouslyOpenedVaults?: string[];
+  onSwitchVault?: (path: string) => Promise<boolean>;
+  onRemoveVaultFromList?: (path: string) => Promise<void>;
   transitionPhase?: VaultEntryTransitionPhase;
   theme?: Theme;
   settings?: AppSettings;
@@ -23,11 +28,16 @@ interface WelcomeScreenProps {
 
 export function WelcomeScreen({
   onOpenVault,
+  currentVaultPath = null,
+  previouslyOpenedVaults = [],
+  onSwitchVault,
+  onRemoveVaultFromList,
   transitionPhase = "idle",
   theme = "dark",
   settings,
 }: WelcomeScreenProps) {
   const [pressedAction, setPressedAction] = useState<VaultEntryAction | null>(null);
+  const [switchingPath, setSwitchingPath] = useState<string | null>(null);
   const pressTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const screenRef = useRef<HTMLDivElement>(null);
   const isDark = isDarkTheme(theme, settings);
@@ -55,6 +65,29 @@ export function WelcomeScreen({
     }, 140);
 
     onOpenVault(action);
+  };
+
+  const recentVaults = previouslyOpenedVaults
+     .filter((path) => path !== currentVaultPath)
+     .slice(0, 5);
+
+  const handleOpenRecent = async (path: string) => {
+    if (actionsDisabled || switchingPath || !onSwitchVault) return;
+    setSwitchingPath(path);
+    try {
+       await onSwitchVault(path);
+    } finally {
+      setSwitchingPath(null);
+    }
+  };
+
+  const handleRemoveRecent = async (
+    event: React.MouseEvent,
+    path: string,
+  ) => {
+    event.stopPropagation();
+    if (actionsDisabled || !onRemoveVaultFromList) return;
+   await onRemoveVaultFromList(path);
   };
 
   return (
@@ -87,6 +120,43 @@ export function WelcomeScreen({
           <Plus size={18} strokeWidth={2} /> Create Vault
         </button>
       </div>
+  {recentVaults.length > 0 && (
+          <div className="mt-10 w-full max-w-[420px] flex flex-col gap-1.5">
+            <span className="text-xs font-medium uppercase tracking-wide text-(--text-secondary) px-1 mb-1">
+              Recent
+            </span>
+            {recentVaults.map((path) => (
+              <div
+                key={path}
+                className="group flex items-center gap-2 px-3 py-2 rounded-lg border border-(--border-subtle) bg-(--bg-secondary) hover:bg-(--bg-hover) hover:border-(--border-medium) transition-colors duration-150"
+              >
+                <button
+                  type="button"
+                  className="flex-1 min-w-0 flex flex-col items-start text-left cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed"
+                  onClick={() => void handleOpenRecent(path)}
+                  disabled={actionsDisabled || switchingPath === path}
+                title={path}
+                >
+                  <span className="text-sm font-medium text-(--text-primary) truncate w-full">
+                  {switchingPath === path ? "Opening..." : vaultName(path)}
+                  </span>
+                  <span className="text-xs text-(--text-secondary) truncate w-full">
+                    {path}
+                  </span>
+                </button>
+                <button
+                type="button"
+                  className="opacity-0 group-hover:opacity-100 p-1 rounded text-(--text-secondary) hover:text-(--text-primary) hover:bg-(--bg-tertiary) transition-all duration-150 cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed"
+                  aria-label={`Remove ${vaultName(path)} from recent vaults`}
+                  onClick={(event) => void handleRemoveRecent(event, path)}
+                  disabled={actionsDisabled}
+                >
+                  <X size={14} strokeWidth={2} />
+                </button>
+              </div>
+            ))}
+          </div>
+      )}
     </div>
   );
 }

--- a/src/hooks/useVaultSession.ts
+++ b/src/hooks/useVaultSession.ts
@@ -193,14 +193,12 @@ export function useVaultSession({
     setFileTree([]);
     setTabs([]);
     setActiveTabId(null);
-    handleOpenNewTab();
     await refreshPreviouslyOpenedVaults();
   }, [
     setVaultPath,
     setFileTree,
     setTabs,
     setActiveTabId,
-    handleOpenNewTab,
     refreshPreviouslyOpenedVaults,
   ]);
 

--- a/src/hooks/useVaultSession.ts
+++ b/src/hooks/useVaultSession.ts
@@ -182,6 +182,28 @@ export function useVaultSession({
     }
   }, [loadVaultData]);
 
+  const handleCloseVault = useCallback(async () => {
+    try {
+      await api.setVaultPath("");
+    } catch (e) {
+      console.error("Failed to clear active vault path:", e);
+    }
+    setVaultPath(null);
+    (window as any).__oo_vault_path = null;
+    setFileTree([]);
+    setTabs([]);
+    setActiveTabId(null);
+    handleOpenNewTab();
+    await refreshPreviouslyOpenedVaults();
+  }, [
+    setVaultPath,
+    setFileTree,
+    setTabs,
+    setActiveTabId,
+    handleOpenNewTab,
+    refreshPreviouslyOpenedVaults,
+  ]);
+
   const handleWelcomeVaultAction = useCallback(
     async (action: VaultEntryAction) => {
       if (vaultEntryTransitionPhase !== "idle") return;
@@ -295,6 +317,7 @@ export function useVaultSession({
     handleOpenVault,
     handleCreateVault,
     handleSwitchVault,
+    handleCloseVault,
     handleWelcomeVaultAction,
     handleCopyVaultId,
     handleRenameVault,

--- a/src/utils/helpers.ts
+++ b/src/utils/helpers.ts
@@ -87,3 +87,8 @@ export function isDarkTheme(theme: string | Theme, settings?: any): boolean {
   const darkThemes = ["dark", "dark-plus", "blue-night", "oceanic", "ember-night", "aurora-grove"];
   return darkThemes.includes(theme as string);
 }
+
+/** Extract the vault name from a path */
+export function vaultName(path: string): string {
+  return path.split(/[/\\]/).filter(Boolean).pop() || path;
+}


### PR DESCRIPTION
## Description

- Added recent vaults to the Welcome Screen so users can reopen previously used vaults without browsing their disk again.
- Reused the existing `previouslyOpenedVaults` data and existing vault functionality, with no new storage or state.
- Clicking a recent vault opens it directly.
- Added an option to remove individual vaults from the recent list.
- Kept Open Vault and Create Vault unchanged.

## Additional change

- Added a Close current vault option in Vault Manager to make it easier to return to the Welcome Screen and test this flow.
- This change is in a separate commit (e87b3b5), so it can be reviewed or removed independently if preferred.

Fixes #85

## Type of Change
- [x] New feature (non-breaking change which adds functionality)

## Verification Performed
- [x] `npm run lint` passed with 0 TypeScript compilation errors.
- [x] `npm run build` or `npm run dev` compiled cleanly.
- [x] Tested functionality locally on desktop application.

Manual testing

1. Opened a vault, then used the new Close current vault option to return to the Welcome Screen.
2. Confirmed that the closed vault appeared under Recent, along with previously opened vaults.
3. Clicked a recent vault and confirmed that it opened immediately without showing the folder picker.
4. Hovered over a recent vault and clicked ✕ to remove it. Confirmed that it was removed without opening the vault.
5. Quit and relaunched the app to confirm that the removed vault remained removed and the change persisted.
6. Confirmed that Open Vault and Create Vault still work as expected for new folders.
7. Confirmed that Settings → Vault Manager still displays the correct vaults and that its existing open/remove functionality continues to work correctly.

## Screenshots
<!-- Welcome Screen with the Recent list, and the Close Vault button in Vault
Manager -->

### Welcome
<img width="1919" height="1011" alt="recent" src="https://github.com/user-attachments/assets/d76672f5-65e5-4dd4-aae4-0bab4199c95c" />

### Recent
<img width="1919" height="1005" alt="welcome" src="https://github.com/user-attachments/assets/ac68a2cf-4384-4404-ad06-ba110d981bc8" />

### Close Current
<img width="1911" height="1006" alt="close" src="https://github.com/user-attachments/assets/6c2d0223-d41c-4997-8e00-47dd033d82ff" />