### PR TITLE
fix: plugin vault trash and disk-backed adapter paths

### DIFF
--- a/src/lib/obsidian-api/app.ts
+++ b/src/lib/obsidian-api/app.ts
@@ -197,7 +197,16 @@ export class OOApp {
         await this.vault.delete(file);
         return true;
       },
-      trashFile: async (file: any) => this.vault.trash(file, false),
+      trashFile: async (file: any) => {
+        let system = false;
+        try {
+          const saved = JSON.parse(localStorage.getItem('openonyx-settings') || '{}');
+          system = saved.deletedFilesMode === 'system-trash';
+        } catch {
+          system = false;
+        }
+        await this.vault.trash(file, system);
+      },
       promptForFileDeletion: async (file: any) => {
         if (confirm(`Are you sure you want to delete ${file.path}?`)) {
           return this.vault.delete(file);

--- a/src/lib/obsidian-api/app.ts
+++ b/src/lib/obsidian-api/app.ts
@@ -3,7 +3,7 @@
  * The root App object that plugins receive.
  */
 
-import { OOVault } from './vault';
+import { applyPreferredTrash, OOVault } from './vault';
 import { OOWorkspace } from './workspace';
 import { OOMetadataCache } from './metadata';
 import { normalizePath, parseYaml, Scope, stringifyYaml } from './utils';
@@ -197,16 +197,7 @@ export class OOApp {
         await this.vault.delete(file);
         return true;
       },
-      trashFile: async (file: any) => {
-        let system = false;
-        try {
-          const saved = JSON.parse(localStorage.getItem('openonyx-settings') || '{}');
-          system = saved.deletedFilesMode === 'system-trash';
-        } catch {
-          system = false;
-        }
-        await this.vault.trash(file, system);
-      },
+      trashFile: async (file: any) => applyPreferredTrash(this.vault, file),
       promptForFileDeletion: async (file: any) => {
         if (confirm(`Are you sure you want to delete ${file.path}?`)) {
           return this.vault.delete(file);

--- a/src/lib/obsidian-api/index.ts
+++ b/src/lib/obsidian-api/index.ts
@@ -226,8 +226,19 @@ export class FileSystemAdapter {
   getFilePath(path: string): string { return `${this.basePath}/${normalizePath(path)}`; }
   getFullPath(path: string): string { return this.getFilePath(path); }
   async readLocalFile(path: string): Promise<ArrayBuffer> { return this.readBinary(path); }
-  async trashLocal(path: string): Promise<void> { await this.delegate?.trashLocal?.(path); }
-  async trashSystem(path: string): Promise<boolean> { return !!(await this.delegate?.trashSystem?.(path)); }
+  async trashLocal(path: string): Promise<void> {
+    if (this.delegate?.trashLocal) {
+      await this.delegate.trashLocal(path);
+      return;
+    }
+    await (window as any).__oo_app?.vault?.adapter?.trashLocal?.(path);
+  }
+  async trashSystem(path: string): Promise<boolean> {
+    if (this.delegate?.trashSystem) {
+      return !!(await this.delegate.trashSystem(path));
+    }
+    return !!(await (window as any).__oo_app?.vault?.adapter?.trashSystem?.(path));
+  }
 }
 
 // ── Keymap (obsidian-git uses Keymap.isModifier) ──
@@ -646,7 +657,14 @@ export class FileManager {
     return confirm(`Delete ${file.path}?`);
   }
   async trashFile(file: TAbstractFile): Promise<void> {
-    await this._app?.vault?.trash(file, false);
+    let system = false;
+    try {
+      const saved = JSON.parse(localStorage.getItem('openonyx-settings') || '{}');
+      system = saved.deletedFilesMode === 'system-trash';
+    } catch {
+      system = false;
+    }
+    await this._app?.vault?.trash(file, system);
   }
   generateMarkdownLink(file: TFile, sourcePath: string, subpath?: string, alias?: string): string {
     const display = alias || file.basename;
@@ -665,7 +683,7 @@ export class FileManager {
     await this._app?.vault?.modify(file, newContent);
   }
   async getAvailablePathForAttachment(filename: string, sourcePath?: string): Promise<string> {
-    return filename;
+    return this._app?.vault?.getAvailablePathForAttachments?.(filename, sourcePath || '') || filename;
   }
 }
 

--- a/src/lib/obsidian-api/index.ts
+++ b/src/lib/obsidian-api/index.ts
@@ -50,6 +50,7 @@ export { OOApp as App } from './app';
 
 // ── Vault ───────────────────────────────────────────
 export { OOVault as Vault } from './vault';
+import { applyPreferredTrash } from './vault';
 
 // ── Workspace & Views ───────────────────────────────
 export {
@@ -657,14 +658,7 @@ export class FileManager {
     return confirm(`Delete ${file.path}?`);
   }
   async trashFile(file: TAbstractFile): Promise<void> {
-    let system = false;
-    try {
-      const saved = JSON.parse(localStorage.getItem('openonyx-settings') || '{}');
-      system = saved.deletedFilesMode === 'system-trash';
-    } catch {
-      system = false;
-    }
-    await this._app?.vault?.trash(file, system);
+    if (this._app?.vault) await applyPreferredTrash(this._app.vault, file);
   }
   generateMarkdownLink(file: TFile, sourcePath: string, subpath?: string, alias?: string): string {
     const display = alias || file.basename;

--- a/src/lib/obsidian-api/vault.ts
+++ b/src/lib/obsidian-api/vault.ts
@@ -9,6 +9,60 @@ import { normalizePath } from './utils';
 
 const api = () => (window as any).electronAPI;
 
+function toVaultRelative(path: string, basePath: string): string {
+  const normalized = normalizePath(path || '');
+  const base = (basePath || '').replace(/\\/g, '/').replace(/\/+$/, '');
+  if (base && (normalized === base || normalized.startsWith(`${base}/`))) {
+    return normalized.slice(base.length).replace(/^\/+/, '');
+  }
+  return normalized === '/' ? '' : normalized;
+}
+
+function localTrashPath(filePath: string): string {
+  return `.trash/${normalizePath(filePath)}`;
+}
+
+async function uniqueVaultPath(filePath: string): Promise<string> {
+  if (!(await api().fileExists?.(filePath))) return filePath;
+  const lastDot = filePath.lastIndexOf('.');
+  const lastSlash = Math.max(filePath.lastIndexOf('/'), filePath.lastIndexOf('\\'));
+  const hasExt = lastDot > lastSlash;
+  const stem = hasExt ? filePath.slice(0, lastDot) : filePath;
+  const ext = hasExt ? filePath.slice(lastDot) : '';
+  let index = 1;
+  let candidate = `${stem}-${index}${ext}`;
+  while (await api().fileExists?.(candidate)) {
+    index += 1;
+    candidate = `${stem}-${index}${ext}`;
+  }
+  return candidate;
+}
+
+async function trashPathLocal(filePath: string): Promise<void> {
+  const dest = await uniqueVaultPath(localTrashPath(filePath));
+  if (api().renameFile) {
+    try {
+      await api().renameFile(filePath, dest);
+      return;
+    } catch {
+      /* fall through to copy-delete */
+    }
+  }
+  const content = (await api().readFile(filePath)) || '';
+  if (api().createFile) await api().createFile(dest, content);
+  else await api().writeFile(dest, content);
+  await api().deleteFile(filePath);
+}
+
+async function trashPathSystem(filePath: string): Promise<boolean> {
+  if (typeof api().trashFile === 'function') {
+    await api().trashFile(filePath);
+    return true;
+  }
+  await trashPathLocal(filePath);
+  return false;
+}
+
 export class OOVault extends Events {
   adapter: any;
   configDir = '.openonyx';
@@ -29,30 +83,73 @@ export class OOVault extends Events {
     this._files.set('/', this._root);
     
     // Initialize adapter with stubs and real implementations where possible
+    const vault = this;
     this.adapter = {
       getBasePath: () => this._path || (window as any).__oo_vault_path || '',
       getName: () => this.getName(),
       fs: {
-        exists: (path: string, cb: any) => { cb(true); },
-        stat: (path: string, cb: any) => { cb(null, { isDirectory: () => false }); },
-        readFile: (path: string, enc: any, cb: any) => { cb(null, ''); },
-        writeFile: (path: string, data: any, enc: any, cb: any) => { cb(null); },
+        exists: (path: string, cb: any) => {
+          void vault.adapter.exists(toVaultRelative(path, vault.adapter.getBasePath()))
+            .then((exists: boolean) => cb(exists))
+            .catch(() => cb(false));
+        },
+        existsSync: (path: string) => {
+          const relative = toVaultRelative(path, vault.adapter.getBasePath());
+          return !!vault.getAbstractFileByPath(relative);
+        },
+        stat: (path: string, cb: any) => {
+          void vault.adapter.stat(toVaultRelative(path, vault.adapter.getBasePath()))
+            .then((stat: any) => {
+              if (!stat) {
+                cb(new Error('ENOENT'));
+                return;
+              }
+              cb(null, {
+                isDirectory: () => stat.type === 'folder',
+                isFile: () => stat.type === 'file',
+                mtime: new Date(stat.mtime || Date.now()),
+                ctime: new Date(stat.ctime || Date.now()),
+                size: stat.size || 0,
+              });
+            })
+            .catch((err: unknown) => cb(err));
+        },
+        readFile: (path: string, enc: any, cb: any) => {
+          const callback = typeof enc === 'function' ? enc : cb;
+          void vault.adapter.read(toVaultRelative(path, vault.adapter.getBasePath()))
+            .then((data: string) => callback(null, data))
+            .catch((err: unknown) => callback(err));
+        },
+        writeFile: (path: string, data: any, enc: any, cb: any) => {
+          const callback = typeof enc === 'function' ? enc : cb;
+          void vault.adapter.writeFile(toVaultRelative(path, vault.adapter.getBasePath()), String(data))
+            .then(() => callback?.(null))
+            .catch((err: unknown) => callback?.(err));
+        },
       },
       // Essential DataAdapter methods
       read: async (path: string) => {
-        const file = this.getAbstractFileByPath(path);
+        const relative = normalizePath(path);
+        const file = this.getAbstractFileByPath(relative);
         if (file instanceof TFile) return await this.read(file);
-        throw new Error('Not a file');
+        const raw = await api().readFile(relative);
+        if (raw === null || raw === undefined) throw new Error('Not a file');
+        return raw;
       },
       write: async (path: string, data: string) => {
         return await this.adapter.writeFile(path, data);
       },
       exists: async (path: string) => {
-        return !!this.getAbstractFileByPath(path);
+        const relative = normalizePath(path);
+        if (this.getAbstractFileByPath(relative)) return true;
+        if (typeof api().fileExists === 'function') {
+          return !!(await api().fileExists(relative));
+        }
+        return false;
       },
       stat: async (path: string) => {
-        const file = this.getAbstractFileByPath(path);
-        if (!file) return null;
+        const relative = normalizePath(path);
+        const file = this.getAbstractFileByPath(relative);
         if (file instanceof TFile) {
           return {
             type: 'file',
@@ -61,29 +158,73 @@ export class OOVault extends Events {
             size: file.stat.size
           };
         }
-        return {
-          type: 'folder',
-          ctime: Date.now(),
-          mtime: Date.now(),
-          size: 0
-        };
+        if (file instanceof TFolder) {
+          return {
+            type: 'folder',
+            ctime: Date.now(),
+            mtime: Date.now(),
+            size: 0
+          };
+        }
+        if (typeof api().fileExists === 'function' && !(await api().fileExists(relative))) {
+          return null;
+        }
+        const parent = relative.includes('/') ? relative.slice(0, relative.lastIndexOf('/')) : '';
+        const name = relative.split('/').pop();
+        if (typeof api().listFiles === 'function') {
+          try {
+            const siblings = await api().listFiles(parent);
+            const entry = (siblings || []).find((item: any) => item.name === name);
+            if (entry) {
+              return {
+                type: entry.isDirectory ? 'folder' : 'file',
+                ctime: entry.modifiedAt || Date.now(),
+                mtime: entry.modifiedAt || Date.now(),
+                size: entry.size || 0,
+              };
+            }
+          } catch {
+            /* hidden or unlistable parent */
+          }
+        }
+        if (typeof api().fileExists === 'function' && await api().fileExists(relative)) {
+          return { type: 'file', ctime: Date.now(), mtime: Date.now(), size: 0 };
+        }
+        return null;
       },
       getResourcePath: (path: string) => {
         const base = this.adapter.getBasePath();
         return `app://local${base}/${path}`;
       },
       list: async (path: string) => {
-        const folder = this.getAbstractFileByPath(path);
-        if (folder instanceof TFolder) {
+        const relative = normalizePath(path);
+        const folder = this.getAbstractFileByPath(relative);
+        if (folder instanceof TFolder && folder.children.length > 0) {
           return {
             files: folder.children.filter(f => f instanceof TFile).map(f => f.path),
             folders: folder.children.filter(f => f instanceof TFolder).map(f => f.path)
           };
         }
+        if (typeof api().listFiles === 'function') {
+          try {
+            const entries = await api().listFiles(relative === '/' ? '' : relative);
+            const prefix = !relative || relative === '/' ? '' : `${relative}/`;
+            return {
+              files: (entries || []).filter((entry: any) => !entry.isDirectory).map((entry: any) => entry.path || `${prefix}${entry.name}`),
+              folders: (entries || []).filter((entry: any) => entry.isDirectory).map((entry: any) => entry.path || `${prefix}${entry.name}`),
+            };
+          } catch {
+            return { files: [], folders: [] };
+          }
+        }
         return { files: [], folders: [] };
       },
-      trashLocal: async () => {},
-      trashSystem: async () => {},
+      trashLocal: async (path: string) => {
+        await trashPathLocal(normalizePath(path));
+      },
+      trashSystem: async (path: string) => {
+        return trashPathSystem(normalizePath(path));
+      },
       mkdir: async (path: string) => {
         await api().createDirectory(path);
         await this.refreshFiles();
@@ -389,8 +530,34 @@ export class OOVault extends Events {
     this.trigger('delete', file);
   }
 
-  async trash(file: TAbstractFile, system: boolean): Promise<void> {
-    return this.delete(file);
+  async trash(file: TAbstractFile, system?: boolean): Promise<void> {
+    const useSystem = system === true;
+    if (useSystem) {
+      await trashPathSystem(file.path);
+    } else {
+      await trashPathLocal(file.path);
+    }
+
+    const removeEntry = (entry: TAbstractFile) => {
+      this._files.delete(entry.path);
+      (window as any).__oo_app?.metadataCache?.deletePath?.(entry.path);
+    };
+
+    if (file instanceof TFolder) {
+      const prefix = file.path.endsWith('/') ? file.path : `${file.path}/`;
+      for (const entry of Array.from(this._files.values())) {
+        if (entry.path === file.path || entry.path.startsWith(prefix)) {
+          removeEntry(entry);
+        }
+      }
+    } else {
+      removeEntry(file);
+    }
+
+    window.dispatchEvent(new CustomEvent('openonyx:file-deleted', {
+      detail: { path: file.path, isDirectory: file instanceof TFolder },
+    }));
+    this.trigger('delete', file);
   }
 
   async rename(file: TAbstractFile, newPath: string): Promise<void> {

--- a/src/lib/obsidian-api/vault.ts
+++ b/src/lib/obsidian-api/vault.ts
@@ -9,13 +9,42 @@ import { normalizePath } from './utils';
 
 const api = () => (window as any).electronAPI;
 
-function toVaultRelative(path: string, basePath: string): string {
-  const normalized = normalizePath(path || '');
-  const base = (basePath || '').replace(/\\/g, '/').replace(/\/+$/, '');
+function slashPath(value: string): string {
+  return (value || '').replace(/\\/g, '/');
+}
+
+/** Map an adapter.fs path (often absolute) back to a vault-relative path. */
+export function toVaultRelative(path: string, basePath: string): string {
+  const normalized = slashPath(path || '').replace(/\/+$/, '');
+  const base = slashPath(basePath || '').replace(/\/+$/, '');
   if (base && (normalized === base || normalized.startsWith(`${base}/`))) {
     return normalized.slice(base.length).replace(/^\/+/, '');
   }
-  return normalized === '/' ? '' : normalized;
+  if (normalized === '/' || normalized === '') return '';
+  return normalizePath(normalized);
+}
+
+export type DeletedFilesMode = 'system-trash' | 'app-trash' | 'permanent';
+
+export function readDeletedFilesMode(): DeletedFilesMode {
+  try {
+    const saved = JSON.parse(localStorage.getItem('openonyx-settings') || '{}');
+    if (saved.deletedFilesMode === 'system-trash' || saved.deletedFilesMode === 'permanent') {
+      return saved.deletedFilesMode;
+    }
+  } catch {
+    /* use local trash */
+  }
+  return 'app-trash';
+}
+
+export async function applyPreferredTrash(vault: OOVault, file: TAbstractFile): Promise<void> {
+  const mode = readDeletedFilesMode();
+  if (mode === 'permanent') {
+    await vault.delete(file);
+    return;
+  }
+  await vault.trash(file, mode === 'system-trash');
 }
 
 function localTrashPath(filePath: string): string {
@@ -38,6 +67,30 @@ async function uniqueVaultPath(filePath: string): Promise<string> {
   return candidate;
 }
 
+async function pathIsDirectory(filePath: string): Promise<boolean> {
+  if (typeof api().listFiles !== 'function') return false;
+  try {
+    await api().listFiles(filePath);
+  } catch {
+    return false;
+  }
+  if (typeof api().fileExists === 'function' && !(await api().fileExists(filePath))) {
+    return false;
+  }
+  const parent = filePath.includes('/') ? filePath.slice(0, filePath.lastIndexOf('/')) : '';
+  const name = filePath.split('/').pop();
+  if (typeof api().listFiles === 'function' && name) {
+    try {
+      const siblings = await api().listFiles(parent);
+      const entry = (siblings || []).find((item: any) => item.name === name);
+      if (entry) return !!entry.isDirectory;
+    } catch {
+      /* parent unlistable — hidden dirs fall through as folders */
+    }
+  }
+  return true;
+}
+
 async function trashPathLocal(filePath: string): Promise<void> {
   const dest = await uniqueVaultPath(localTrashPath(filePath));
   if (api().renameFile) {
@@ -45,9 +98,37 @@ async function trashPathLocal(filePath: string): Promise<void> {
       await api().renameFile(filePath, dest);
       return;
     } catch {
-      /* fall through to copy-delete */
+      /* fall through */
     }
   }
+
+  if (await pathIsDirectory(filePath)) {
+    if (api().createDirectory) await api().createDirectory(dest);
+    const entries = typeof api().listFiles === 'function' ? await api().listFiles(filePath).catch(() => []) : [];
+    for (const entry of entries || []) {
+      const childPath = entry.path || `${filePath.replace(/\/$/, '')}/${entry.name}`;
+      const childDest = `${dest}/${entry.name}`;
+      if (api().renameFile) {
+        try {
+          await api().renameFile(childPath, childDest);
+          continue;
+        } catch {
+          /* copy below */
+        }
+      }
+      if (entry.isDirectory) {
+        await trashPathLocal(childPath);
+        continue;
+      }
+      const content = (await api().readFile(childPath)) || '';
+      if (api().createFile) await api().createFile(childDest, content);
+      else await api().writeFile(childDest, content);
+      await api().deleteFile(childPath);
+    }
+    if (api().deleteDirectory) await api().deleteDirectory(filePath);
+    return;
+  }
+
   const content = (await api().readFile(filePath)) || '';
   if (api().createFile) await api().createFile(dest, content);
   else await api().writeFile(dest, content);
@@ -169,23 +250,13 @@ export class OOVault extends Events {
         if (typeof api().fileExists === 'function' && !(await api().fileExists(relative))) {
           return null;
         }
-        const parent = relative.includes('/') ? relative.slice(0, relative.lastIndexOf('/')) : '';
-        const name = relative.split('/').pop();
-        if (typeof api().listFiles === 'function') {
-          try {
-            const siblings = await api().listFiles(parent);
-            const entry = (siblings || []).find((item: any) => item.name === name);
-            if (entry) {
-              return {
-                type: entry.isDirectory ? 'folder' : 'file',
-                ctime: entry.modifiedAt || Date.now(),
-                mtime: entry.modifiedAt || Date.now(),
-                size: entry.size || 0,
-              };
-            }
-          } catch {
-            /* hidden or unlistable parent */
-          }
+        if (await pathIsDirectory(relative)) {
+          return {
+            type: 'folder',
+            ctime: Date.now(),
+            mtime: Date.now(),
+            size: 0,
+          };
         }
         if (typeof api().fileExists === 'function' && await api().fileExists(relative)) {
           return { type: 'file', ctime: Date.now(), mtime: Date.now(), size: 0 };

--- a/src/utils/mockAPI.ts
+++ b/src/utils/mockAPI.ts
@@ -323,6 +323,7 @@ export function createMockAPI(): ElectronAPI {
     },
 
     trashFile: async (filePath: string) => {
+      mockFiles[`__system_trash__/${filePath}`] = mockFiles[filePath] || "";
       delete mockFiles[filePath];
     },
 

--- a/tests/plugin-runtime.test.ts
+++ b/tests/plugin-runtime.test.ts
@@ -62,6 +62,9 @@ beforeEach(() => {
     dataWrite: vi.fn(async () => {}),
     dataDelete: vi.fn(async () => {}),
     dataList: vi.fn(async () => []),
+    listFiles: vi.fn(async () => []),
+    fileExists: vi.fn(async () => false),
+    trashFile: vi.fn(async () => {}),
   };
 });
 
@@ -846,5 +849,101 @@ body.theme-dark .plain-plugin-button { border-color: blue; }
     expect(editor.offsetToPos(7)).toEqual({ line: 1, ch: 2 });
 
     view.destroy();
+  });
+});
+
+describe('plugin vault adapter compatibility', () => {
+  function installMapFs(initial: Record<string, string> = {}) {
+    const files = new Map<string, string>(Object.entries(initial));
+    const api = (window as any).electronAPI;
+    api.readFile = vi.fn(async (path: string) => (files.has(path) ? files.get(path)! : null));
+    api.writeFile = vi.fn(async (path: string, content: string) => {
+      files.set(path, content);
+    });
+    api.createFile = vi.fn(async (path: string, content?: string) => {
+      if (!files.has(path)) files.set(path, content || '');
+    });
+    api.deleteFile = vi.fn(async (path: string) => {
+      files.delete(path);
+    });
+    api.fileExists = vi.fn(async (path: string) => files.has(path));
+    api.renameFile = vi.fn(async (oldPath: string, newPath: string) => {
+      if (files.has(oldPath)) {
+        files.set(newPath, files.get(oldPath)!);
+        files.delete(oldPath);
+        return;
+      }
+      const prefix = oldPath.endsWith('/') ? oldPath : `${oldPath}/`;
+      const nextPrefix = newPath.endsWith('/') ? newPath : `${newPath}/`;
+      for (const key of Array.from(files.keys())) {
+        if (key.startsWith(prefix)) {
+          files.set(nextPrefix + key.slice(prefix.length), files.get(key)!);
+          files.delete(key);
+        }
+      }
+    });
+    api.listFiles = vi.fn(async (dirPath?: string) => {
+      const prefix = dirPath ? `${dirPath.replace(/\/$/, '')}/` : '';
+      const names = new Map<string, { name: string; path: string; isDirectory: boolean }>();
+      for (const key of files.keys()) {
+        if (prefix && !key.startsWith(prefix)) continue;
+        const rest = prefix ? key.slice(prefix.length) : key;
+        const [name, ...more] = rest.split('/');
+        if (!name) continue;
+        const isDirectory = more.length > 0;
+        const path = prefix ? `${prefix.replace(/\/$/, '')}/${name}` : name;
+        if (!names.has(name) || isDirectory) {
+          names.set(name, { name, path, isDirectory });
+        }
+      }
+      return Array.from(names.values());
+    });
+    api.trashFile = vi.fn(async (path: string) => {
+      files.set(`__system_trash__/${path}`, files.get(path) || '');
+      files.delete(path);
+    });
+    return files;
+  }
+
+  it('lets plugins read, list, and stat hidden config folders through the adapter', async () => {
+    const files = installMapFs({
+      '.obsidian/snippets/wide.css': 'body { max-width: none; }',
+      '.openonyx/plugins/demo/data.json': '{"ok":true}',
+    });
+    const app = new OOApp();
+
+    expect(await app.vault.adapter.exists('.obsidian/snippets/wide.css')).toBe(true);
+    expect(await app.vault.adapter.read('.obsidian/snippets/wide.css')).toContain('max-width');
+    const listing = await app.vault.adapter.list('.obsidian/snippets');
+    expect(listing.files.some((path: string) => path.endsWith('wide.css'))).toBe(true);
+    const stat = await app.vault.adapter.stat('.openonyx/plugins/demo/data.json');
+    expect(stat?.type).toBe('file');
+    expect(files.has('.openonyx/plugins/demo/data.json')).toBe(true);
+  });
+
+  it('moves notes to .trash instead of deleting them when plugins call vault.trash(file, false)', async () => {
+    const files = installMapFs({ 'Keep.md': 'safe' });
+    const app = new OOApp();
+    const note = await app.vault.create('Keep.md', 'safe');
+    files.set('Keep.md', 'safe');
+
+    await app.vault.trash(note, false);
+
+    expect(files.has('Keep.md')).toBe(false);
+    expect(files.get('.trash/Keep.md')).toBe('safe');
+    expect(app.vault.getAbstractFileByPath('Keep.md')).toBeNull();
+  });
+
+  it('uses the system trash API when plugins call vault.trash(file, true)', async () => {
+    const files = installMapFs({ 'Gone.md': 'bye' });
+    const app = new OOApp();
+    const note = await app.vault.create('Gone.md', 'bye');
+    files.set('Gone.md', 'bye');
+
+    await app.vault.trash(note, true);
+
+    expect(files.has('Gone.md')).toBe(false);
+    expect(files.get('__system_trash__/Gone.md')).toBe('bye');
+    expect((window as any).electronAPI.trashFile).toHaveBeenCalledWith('Gone.md');
   });
 });

--- a/tests/plugin-runtime.test.ts
+++ b/tests/plugin-runtime.test.ts
@@ -853,9 +853,21 @@ body.theme-dark .plain-plugin-button { border-color: blue; }
 });
 
 describe('plugin vault adapter compatibility', () => {
+  beforeEach(() => {
+    localStorage.removeItem('openonyx-settings');
+    delete (window as any).__oo_vault_path;
+  });
+
   function installMapFs(initial: Record<string, string> = {}) {
     const files = new Map<string, string>(Object.entries(initial));
     const api = (window as any).electronAPI;
+    const hasPrefix = (path: string) => {
+      const prefix = path.endsWith('/') ? path : `${path}/`;
+      for (const key of files.keys()) {
+        if (key.startsWith(prefix)) return true;
+      }
+      return false;
+    };
     api.readFile = vi.fn(async (path: string) => (files.has(path) ? files.get(path)! : null));
     api.writeFile = vi.fn(async (path: string, content: string) => {
       files.set(path, content);
@@ -863,10 +875,17 @@ describe('plugin vault adapter compatibility', () => {
     api.createFile = vi.fn(async (path: string, content?: string) => {
       if (!files.has(path)) files.set(path, content || '');
     });
+    api.createDirectory = vi.fn(async () => {});
     api.deleteFile = vi.fn(async (path: string) => {
       files.delete(path);
     });
-    api.fileExists = vi.fn(async (path: string) => files.has(path));
+    api.deleteDirectory = vi.fn(async (dirPath: string) => {
+      const prefix = dirPath.endsWith('/') ? dirPath : `${dirPath}/`;
+      for (const key of Array.from(files.keys())) {
+        if (key === dirPath || key.startsWith(prefix)) files.delete(key);
+      }
+    });
+    api.fileExists = vi.fn(async (path: string) => files.has(path) || hasPrefix(path));
     api.renameFile = vi.fn(async (oldPath: string, newPath: string) => {
       if (files.has(oldPath)) {
         files.set(newPath, files.get(oldPath)!);
@@ -883,7 +902,11 @@ describe('plugin vault adapter compatibility', () => {
       }
     });
     api.listFiles = vi.fn(async (dirPath?: string) => {
-      const prefix = dirPath ? `${dirPath.replace(/\/$/, '')}/` : '';
+      const target = dirPath || '';
+      if (target && files.has(target) && !hasPrefix(target)) {
+        throw new Error('ENOTDIR');
+      }
+      const prefix = target ? `${target.replace(/\/$/, '')}/` : '';
       const names = new Map<string, { name: string; path: string; isDirectory: boolean }>();
       for (const key of files.keys()) {
         if (prefix && !key.startsWith(prefix)) continue;
@@ -945,5 +968,95 @@ describe('plugin vault adapter compatibility', () => {
     expect(files.has('Gone.md')).toBe(false);
     expect(files.get('__system_trash__/Gone.md')).toBe('bye');
     expect((window as any).electronAPI.trashFile).toHaveBeenCalledWith('Gone.md');
+  });
+
+  it('stats a hidden config directory as a folder, not a file', async () => {
+    installMapFs({
+      '.obsidian/snippets/wide.css': 'body {}',
+      '.obsidian/appearance.json': '{}',
+    });
+    const app = new OOApp();
+
+    const stat = await app.vault.adapter.stat('.obsidian');
+    expect(stat?.type).toBe('folder');
+  });
+
+  it('resolves adapter.fs exists() for absolute Unix vault paths', async () => {
+    (window as any).__oo_vault_path = '/Users/me/vault';
+    const files = installMapFs({ 'Note.md': 'hello' });
+    const app = new OOApp();
+    await app.vault.create('Note.md', 'hello');
+    files.set('Note.md', 'hello');
+
+    await new Promise<void>((resolve, reject) => {
+      app.vault.adapter.fs.exists('/Users/me/vault/Note.md', (exists: boolean) => {
+        try {
+          expect(exists).toBe(true);
+          resolve();
+        } catch (error) {
+          reject(error);
+        }
+      });
+    });
+  });
+
+  it('moves a folder and its children into .trash when plugins trash a directory', async () => {
+    const files = installMapFs({
+      'Notes/A.md': 'a',
+      'Notes/B.md': 'b',
+    });
+    const app = new OOApp();
+    await app.vault.createFolder('Notes');
+    const folder = app.vault.getAbstractFileByPath('Notes');
+    await app.vault.create('Notes/A.md', 'a');
+    await app.vault.create('Notes/B.md', 'b');
+    files.set('Notes/A.md', 'a');
+    files.set('Notes/B.md', 'b');
+
+    await app.vault.trash(folder!, false);
+
+    expect(files.has('Notes/A.md')).toBe(false);
+    expect(files.has('Notes/B.md')).toBe(false);
+    expect(files.get('.trash/Notes/A.md')).toBe('a');
+    expect(files.get('.trash/Notes/B.md')).toBe('b');
+  });
+
+  it('copies a folder into .trash when renameFile fails', async () => {
+    const files = installMapFs({
+      'Inbox/One.md': 'one',
+    });
+    const app = new OOApp();
+    await app.vault.createFolder('Inbox');
+    const folder = app.vault.getAbstractFileByPath('Inbox');
+    await app.vault.create('Inbox/One.md', 'one');
+    files.set('Inbox/One.md', 'one');
+
+    let renameCalls = 0;
+    (window as any).electronAPI.renameFile = vi.fn(async (oldPath: string, newPath: string) => {
+      renameCalls += 1;
+      if (oldPath === 'Inbox') throw new Error('EXDEV');
+      files.set(newPath, files.get(oldPath)!);
+      files.delete(oldPath);
+    });
+
+    await app.vault.trash(folder!, false);
+
+    expect(renameCalls).toBeGreaterThan(0);
+    expect(files.has('Inbox/One.md')).toBe(false);
+    expect(files.get('.trash/Inbox/One.md')).toBe('one');
+  });
+
+  it('honors permanent delete in FileManager.trashFile', async () => {
+    const files = installMapFs({ 'Temp.md': 'x' });
+    localStorage.setItem('openonyx-settings', JSON.stringify({ deletedFilesMode: 'permanent' }));
+    const app = new OOApp();
+    const note = await app.vault.create('Temp.md', 'x');
+    files.set('Temp.md', 'x');
+
+    await app.fileManager.trashFile(note);
+
+    expect(files.has('Temp.md')).toBe(false);
+    expect(files.has('.trash/Temp.md')).toBe(false);
+    expect(files.has('__system_trash__/Temp.md')).toBe(false);
   });
 });

--- a/tests/vault-relative.test.ts
+++ b/tests/vault-relative.test.ts
@@ -1,0 +1,22 @@
+// @vitest-environment jsdom
+
+import { describe, expect, it } from "vitest";
+import { toVaultRelative } from "../src/lib/obsidian-api/vault";
+
+describe("toVaultRelative", () => {
+  it("strips a Unix vault prefix from an absolute path", () => {
+    expect(toVaultRelative("/Users/me/vault/Note.md", "/Users/me/vault")).toBe("Note.md");
+    expect(toVaultRelative("/Users/me/vault/folder/A.md", "/Users/me/vault")).toBe("folder/A.md");
+  });
+
+  it("strips a Windows vault prefix from an absolute path", () => {
+    expect(toVaultRelative("C:\\Users\\me\\vault\\Note.md", "C:\\Users\\me\\vault")).toBe("Note.md");
+  });
+
+  it("leaves already-relative paths alone", () => {
+    expect(toVaultRelative("Note.md", "/Users/me/vault")).toBe("Note.md");
+    expect(toVaultRelative(".obsidian/snippets/wide.css", "/Users/me/vault")).toBe(
+      ".obsidian/snippets/wide.css",
+    );
+  });
+});


### PR DESCRIPTION
## Summary

Plugins that use the Obsidian vault adapter could not see hidden config folders (`.obsidian`, `.openonyx`) because `exists` / `list` / `stat` / `read` only looked at the in-memory file tree. `vault.trash()` also permanently deleted notes.

This wires the adapter to the real vault and makes trash behave like Obsidian.

Fixes #114
Fixes #74

## What changed

- Adapter `exists`, `list`, `stat`, and `read` fall through to disk so plugin config, snippets, and `data.json` are visible.
- `adapter.stat('.obsidian')` reports a folder, not a file.
- `adapter.fs` accepts absolute Unix/Windows vault paths.
- `vault.trash(file, false)` moves files and folders to `.trash/`.
- `vault.trash(file, true)` uses system trash.
- `FileManager.trashFile` follows the Deleted files setting, including permanent delete.

## Test plan

- [x] `npx vitest run tests/plugin-runtime.test.ts tests/vault-relative.test.ts`
- [x] Hidden folder exists/read/list/stat
- [x] Local file trash lands in `.trash/`
- [x] System trash calls `trashFile`
- [x] Folder trash (rename and rename-fail fallback)
- [x] Permanent delete via `FileManager.trashFile`
- [x] Absolute `adapter.fs.exists('/Users/me/vault/Note.md')`
- [x] `tsc --noEmit`
- [x] Obsidian export audit 158/158

## Out of scope

This is not a full plugin-compat sweep. CSS snippets, permission enforcement, and remaining API stubs are unchanged.