### PR TITLE
fix(website): make the Vercel production build resolve desktop packages

### DIFF
--- a/website/README.md
+++ b/website/README.md
@@ -19,3 +19,13 @@ Dev server: `http://localhost:4173`
 npm run build
 npm run preview
 ```
+
+## Vercel
+
+Set **Root Directory** to `website`. Use Node 22. The production build runs
+`prebuild`, which installs the desktop app's production dependencies from the
+repo root. The hero editor and graph import those packages from `../src`.
+
+Do not set the project root to the repository root unless you also change the
+install command to `npm install && cd website && npm install` and the output
+directory to `website/dist`.

--- a/website/package.json
+++ b/website/package.json
@@ -5,8 +5,12 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
+    "prebuild": "node scripts/ensure-app-deps.mjs",
     "build": "vite build",
     "preview": "vite preview"
+  },
+  "engines": {
+    "node": ">=22"
   },
   "dependencies": {
     "gsap": "^3.15.0",

--- a/website/scripts/ensure-app-deps.mjs
+++ b/website/scripts/ensure-app-deps.mjs
@@ -1,0 +1,42 @@
+/**
+ * The marketing site embeds the real desktop Editor / graph.
+ * Those modules live in ../src and resolve packages from the repo root.
+ * Vercel Root Directory is `website/`, so that root install never runs
+ * unless we do it here.
+ */
+import { existsSync } from "node:fs";
+import { spawnSync } from "node:child_process";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const websiteDir = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+const repoRoot = resolve(websiteDir, "..");
+const rootPkg = resolve(repoRoot, "package.json");
+const marker = resolve(repoRoot, "node_modules", "@xenova", "transformers");
+
+if (!existsSync(rootPkg)) {
+  console.log("[website] no parent package.json — skip desktop dependency install");
+  process.exit(0);
+}
+
+if (existsSync(marker)) {
+  console.log("[website] desktop dependencies already present");
+  process.exit(0);
+}
+
+console.log("[website] installing desktop production dependencies for the embedded editor");
+const result = spawnSync("npm", ["install", "--omit=dev", "--ignore-scripts", "--no-fund", "--no-audit"], {
+  cwd: repoRoot,
+  stdio: "inherit",
+  env: process.env,
+});
+
+if (result.status !== 0) {
+  console.error("[website] failed to install desktop dependencies");
+  process.exit(result.status ?? 1);
+}
+
+if (!existsSync(marker)) {
+  console.error("[website] @xenova/transformers is still missing after install");
+  process.exit(1);
+}

--- a/website/src/shims/electron.ts
+++ b/website/src/shims/electron.ts
@@ -1,0 +1,10 @@
+/** Desktop-only module. The marketing site never loads Electron. */
+export default {};
+export const ipcRenderer = undefined;
+export const contextBridge = undefined;
+export const app = undefined;
+export const shell = undefined;
+export const dialog = undefined;
+export const clipboard = undefined;
+export const BrowserWindow = undefined;
+export const safeStorage = undefined;

--- a/website/vercel.json
+++ b/website/vercel.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "framework": "vite",
+  "installCommand": "npm install",
+  "buildCommand": "npm run build",
+  "outputDirectory": "dist"
+}

--- a/website/vite.config.ts
+++ b/website/vite.config.ts
@@ -10,6 +10,7 @@ export default defineConfig({
   resolve: {
     alias: {
       "@": path.resolve(appRoot, "src"),
+      electron: path.resolve(__dirname, "src/shims/electron.ts"),
       "onnxruntime-node": "onnxruntime-web",
     },
     dedupe: ["react", "react-dom"],


### PR DESCRIPTION
## Summary

Vercel builds with Root Directory `website/`, so it never installs the desktop app dependencies. The hero editor still imports `../src`, which needs `@xenova/transformers` and the rest of the root `package.json`. Rollup then fails:

`failed to resolve import \"@xenova/transformers\"`

`npm run build` now runs a prebuild that installs the repo-root **production** dependencies (`--omit=dev`, no Electron). Node 22 is declared for Vercel.

Do not treat this PR as a deploy. Merge it, then deploy from your Vercel account.

## Test plan

- [x] `cd website && npm run build` succeeds
- [x] Prebuild no-ops when root `node_modules` already exists
- [ ] After merge, Vercel deploy from your account

Fixes the current Vercel production failure on `main`.