### PR TITLE
Add security headers to website (#123)

### DIFF
--- a/website/vercel.json
+++ b/website/vercel.json
@@ -3,5 +3,13 @@
   "framework": "vite",
   "installCommand": "npm install",
   "buildCommand": "npm run build",
-  "outputDirectory": "dist"
+  "outputDirectory": "dist",
+  "headers": [{
+    "source": "/(.*)",
+    "headers": [
+      {"key": "Content-Security-Policy", "value": "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval'; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob: https:; font-src 'self' data: https:; connect-src 'self' https:; object-src 'none'; frame-ancestors 'none'"},
+      {"key": "Referrer-Policy", "value": "strict-origin-when-cross-origin"},
+      {"key": "X-Content-Type-Options", "value": "nosniff"}
+    ]
+  }]
 }


### PR DESCRIPTION
## Description

Adds security headers to the OpenOnyx website deployment configuration.

A passive security scan of the deployed website identified three missing HTTP security headers:

- `Content-Security-Policy`
- `Referrer-Policy`
- `X-Content-Type-Options`

This change adds compatible values for these headers at the Vercel deployment layer. The scope is intentionally limited to the website configuration and does not modify application logic or UI behavior.

**This is a non-breaking change.** No application code, dependencies, routing, or intentional behavior changes.

Fixes #123

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Verification Performed

- [ ] `npm run lint` passed with 0 TypeScript compilation errors.
- [ ] `npm run build` or `npm run dev` compiled cleanly.
- [ ] Tested functionality locally on desktop application.

### Configuration verification

- Added `Content-Security-Policy`.
- Added `Referrer-Policy: strict-origin-when-cross-origin`.
- Added `X-Content-Type-Options: nosniff`.
- Confirmed the change is limited to the website's Vercel configuration.

## Screenshots

Not applicable - this change affects HTTP response headers only.

Fixes #123