### PR TITLE
Fix website first-visit 404, downloads, and copy

### DIFF
--- a/website/index.html
+++ b/website/index.html
@@ -16,14 +16,21 @@
       property="og:description"
       content="OpenOnyx is a local-first knowledge workspace with built-in Spaces, an AI graph, and an Apache-2.0 desktop. Your notes stay as Markdown. No account required."
     />
-    <meta property="og:image" content="/images/banner.webp" />
+    <meta
+      property="og:image"
+      content="https://raw.githubusercontent.com/OpenOnyx/OpenOnyx/main/website/public/images/banner.webp"
+    />
+    <link rel="canonical" href="/" />
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:title" content="OpenOnyx — Local-first knowledge workspace" />
     <meta
       name="twitter:description"
       content="OpenOnyx is a local-first knowledge workspace with built-in Spaces, an AI graph, and an Apache-2.0 desktop. Your notes stay as Markdown. No account required."
     />
-    <meta name="twitter:image" content="/images/banner.webp" />
+    <meta
+      name="twitter:image"
+      content="https://raw.githubusercontent.com/OpenOnyx/OpenOnyx/main/website/public/images/banner.webp"
+    />
     <title>OpenOnyx — Local-first knowledge workspace</title>
     <script>
       try {
@@ -33,6 +40,22 @@
         }
         document.documentElement.dataset.theme = t;
         document.documentElement.style.colorScheme = t;
+        var origin = location.origin;
+        var img = origin + "/images/banner.webp";
+        var url = origin + location.pathname + location.search;
+        var ogImage = document.querySelector('meta[property="og:image"]');
+        var twImage = document.querySelector('meta[name="twitter:image"]');
+        var ogUrl = document.querySelector('meta[property="og:url"]');
+        var canon = document.querySelector('link[rel="canonical"]');
+        if (ogImage) ogImage.setAttribute("content", img);
+        if (twImage) twImage.setAttribute("content", img);
+        if (!ogUrl) {
+          ogUrl = document.createElement("meta");
+          ogUrl.setAttribute("property", "og:url");
+          document.head.appendChild(ogUrl);
+        }
+        ogUrl.setAttribute("content", url);
+        if (canon) canon.setAttribute("href", url);
       } catch (e) {}
     </script>
     <link rel="preconnect" href="https://fonts.googleapis.com" />

--- a/website/src/App.tsx
+++ b/website/src/App.tsx
@@ -3,6 +3,7 @@ import { Layout } from "./components/Layout";
 import { Docs } from "./pages/Docs";
 import { Download } from "./pages/Download";
 import { Home } from "./pages/Home";
+import { NotFound } from "./pages/NotFound";
 
 export function App() {
   return (
@@ -12,6 +13,7 @@ export function App() {
         <Route path="download" element={<Download />} />
         <Route path="docs" element={<Navigate to="/docs/start" replace />} />
         <Route path="docs/:slug" element={<Docs />} />
+        <Route path="*" element={<NotFound />} />
       </Route>
     </Routes>
   );

--- a/website/src/components/SiteHeader.tsx
+++ b/website/src/components/SiteHeader.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from "react";
 import { NavLink, useLocation } from "react-router-dom";
 import { PRODUCT } from "../data/facts";
+import { paletteHotkeyLabel } from "../lib/hotkey";
 import { useTheme } from "../theme";
 
 function formatCount(n: number) {
@@ -83,8 +84,9 @@ export function SiteHeader() {
             type="button"
             className="meta-chip meta-chip-palette"
             onClick={() => window.dispatchEvent(new Event("openonyx:palette"))}
+            aria-label={`Open command palette (${paletteHotkeyLabel()})`}
           >
-            ⌘K
+            {paletteHotkeyLabel()}
           </button>
           <a className="meta-chip meta-chip-version" href={PRODUCT.latestRelease} target="_blank" rel="noreferrer">
             v{PRODUCT.version}

--- a/website/src/components/commands.tsx
+++ b/website/src/components/commands.tsx
@@ -2,6 +2,7 @@ import { createContext, useContext, useEffect, useMemo, useState, type ReactNode
 import { useNavigate } from "react-router-dom";
 import { PRODUCT } from "../data/facts";
 import { DOC_PAGES } from "../data/docs";
+import { isApplePlatform } from "../lib/hotkey";
 
 export type SiteCommand = {
   id: string;
@@ -110,7 +111,7 @@ function CommandPalette({ commands, onClose }: { commands: SiteCommand[]; onClos
         onClick={(event) => event.stopPropagation()}
       >
         <div className="palette-input">
-          <span aria-hidden>⌘</span>
+          <span aria-hidden>{isApplePlatform() ? "⌘" : "Ctrl"}</span>
           <input
             autoFocus
             value={query}

--- a/website/src/components/product/Workspace.tsx
+++ b/website/src/components/product/Workspace.tsx
@@ -7,6 +7,7 @@ import { DEFAULT_SETTINGS } from "../../../../src/components/settings/SettingsPa
 import { getAPI } from "../../../../src/utils/api";
 import type { FileEntry, Tab, ViewMode } from "../../../../src/types";
 import { PLUGINS_TESTED } from "../../data/facts";
+import { paletteHotkeyLabel } from "../../lib/hotkey";
 import vault from "../../data/real-vault.json";
 import { useTheme } from "../../theme";
 import { useCommands, type SiteCommand } from "../commands";
@@ -218,7 +219,7 @@ export function Workspace() {
           ))}
         </div>
         <button type="button" className="oo-k" onClick={openPalette}>
-          ⌘K
+          {paletteHotkeyLabel()}
         </button>
       </div>
 

--- a/website/src/data/docs.tsx
+++ b/website/src/data/docs.tsx
@@ -301,7 +301,8 @@ npm run dev`}</pre>
             <b>AI graph</b> — suggested links, bridges, and idea islands from on-device embeddings.
           </li>
           <li>
-            <b>AI writing</b> — inline rewrite, expand, and simplify, plus answers grounded in your notes.
+            <b>AI writing</b> — optional OpenAI or OpenRouter keys unlock rewrite, expand, and simplify. Local
+            embeddings need no key.
           </li>
           <li>
             <b>Your cloud, or none</b> — optional Supabase that you own. No required account, no product

--- a/website/src/data/facts.ts
+++ b/website/src/data/facts.ts
@@ -100,7 +100,7 @@ export const VERSUS_OBSIDIAN: Array<{ item: string; us: string; them: string; wi
   },
   {
     item: "AI writing",
-    us: "Inline rewrite, expand, simplify, plus vault-grounded answers. Local path needs no key.",
+    us: "Rewrite, expand, and simplify with an optional OpenAI or OpenRouter key. Local embeddings and Spaces retrieval need no key.",
     them: "Community plugins or paid add-ons",
     win: true,
   },
@@ -237,14 +237,25 @@ export const THEATER = [
   { ...STORY[5], kicker: "07 · sync" },
 ] as const;
 
+const RELEASE_FILES = `${PRODUCT.repo}/releases/download/v${PRODUCT.version}`;
+
 export const DOWNLOADS = {
   macNote:
     'If macOS says the app is from an unidentified developer or is "damaged", right-click OpenOnyx.app and choose Open, or run: xattr -cr /Applications/OpenOnyx.app',
   windowsNote:
-    "Download the .exe installer from Releases. Free code signing is provided by SignPath.io; the certificate is issued by SignPath Foundation.",
+    "Free code signing is provided by SignPath.io; the certificate is issued by SignPath Foundation.",
   linuxNote:
     "Download .AppImage, .deb, or Arch .pkg.tar.zst from Releases, or run the official installer script.",
   linuxInstall: "curl -fsSL https://raw.githubusercontent.com/OpenOnyx/OpenOnyx/main/scripts/install.sh | bash",
+  files: {
+    macArmDmg: `${RELEASE_FILES}/OpenOnyx-${PRODUCT.version}-arm64.dmg`,
+    macIntelDmg: `${RELEASE_FILES}/OpenOnyx-${PRODUCT.version}.dmg`,
+    winSetup: `${RELEASE_FILES}/OpenOnyx.Setup.${PRODUCT.version}.exe`,
+    winPortable: `${RELEASE_FILES}/OpenOnyx.${PRODUCT.version}.exe`,
+    linuxAppImage: `${RELEASE_FILES}/OpenOnyx-${PRODUCT.version}.AppImage`,
+    linuxDeb: `${RELEASE_FILES}/openonyx_${PRODUCT.version}_amd64.deb`,
+    linuxArch: `${RELEASE_FILES}/openonyx-${PRODUCT.version}-1-x86_64.pkg.tar.zst`,
+  },
 } as const;
 
 export const FEATURES = [
@@ -340,7 +351,7 @@ export const FEATURES = [
     id: "export",
     kicker: "12",
     title: "Export tooling",
-    body: "Managed Pandoc 3.10 WASM backend for export plugins, plus Node and Electron shims so desktop plugin workflows keep working.",
+    body: "Plugin-driven export: a bundled Pandoc 3.10 WASM backend plus Node and Electron shims. There is no separate export guide — start from Plugins.",
     points: ["Pandoc backend", "Plugin shims", "Canvas compat tests"],
     href: "/docs/plugins",
   },

--- a/website/src/lib/hotkey.ts
+++ b/website/src/lib/hotkey.ts
@@ -1,0 +1,11 @@
+/** Website palette is Ctrl/Cmd+K. Label it for the machine in front of the reader. */
+export function isApplePlatform() {
+  if (typeof navigator === "undefined") return false;
+  const platform = navigator.platform || "";
+  const ua = navigator.userAgent || "";
+  return /Mac|iPhone|iPad|iPod/.test(platform) || /Mac OS X|iPhone|iPad|iPod/.test(ua);
+}
+
+export function paletteHotkeyLabel() {
+  return isApplePlatform() ? "⌘K" : "Ctrl+K";
+}

--- a/website/src/lib/meta.ts
+++ b/website/src/lib/meta.ts
@@ -1,37 +1,80 @@
 import { useEffect } from "react";
 import { PRODUCT } from "../data/facts";
 
+function setContent(selector: string, value: string) {
+  const node = document.querySelector(selector);
+  if (node) node.setAttribute("content", value);
+}
+
+function ensureMeta(selector: string, attrs: Record<string, string>) {
+  let node = document.querySelector(selector);
+  if (!node) {
+    node = document.createElement("meta");
+    for (const [key, value] of Object.entries(attrs)) node.setAttribute(key, value);
+    document.head.appendChild(node);
+  }
+  return node;
+}
+
+function ensureLink(rel: string) {
+  let node = document.querySelector(`link[rel="${rel}"]`);
+  if (!node) {
+    node = document.createElement("link");
+    node.setAttribute("rel", rel);
+    document.head.appendChild(node);
+  }
+  return node;
+}
+
+function pageUrl() {
+  return `${window.location.origin}${window.location.pathname}${window.location.search}`;
+}
+
+function pageImage() {
+  return `${window.location.origin}/images/banner.webp`;
+}
+
 export function usePageMeta(title: string, description: string = PRODUCT.description) {
   useEffect(() => {
     const previousTitle = document.title;
-    document.title = title;
-
-    const set = (selector: string, value: string) => {
-      const node = document.querySelector(selector);
-      if (node) node.setAttribute("content", value);
-    };
-
     const previousDescription = document.querySelector('meta[name="description"]')?.getAttribute("content") ?? "";
     const previousOgTitle = document.querySelector('meta[property="og:title"]')?.getAttribute("content") ?? "";
     const previousOgDescription =
       document.querySelector('meta[property="og:description"]')?.getAttribute("content") ?? "";
+    const previousOgUrl = document.querySelector('meta[property="og:url"]')?.getAttribute("content") ?? "";
+    const previousOgImage = document.querySelector('meta[property="og:image"]')?.getAttribute("content") ?? "";
     const previousTwitterTitle = document.querySelector('meta[name="twitter:title"]')?.getAttribute("content") ?? "";
     const previousTwitterDescription =
       document.querySelector('meta[name="twitter:description"]')?.getAttribute("content") ?? "";
+    const previousTwitterImage = document.querySelector('meta[name="twitter:image"]')?.getAttribute("content") ?? "";
+    const previousCanonical = document.querySelector('link[rel="canonical"]')?.getAttribute("href") ?? "";
 
-    set('meta[name="description"]', description);
-    set('meta[property="og:title"]', title);
-    set('meta[property="og:description"]', description);
-    set('meta[name="twitter:title"]', title);
-    set('meta[name="twitter:description"]', description);
+    const url = pageUrl();
+    const image = pageImage();
+
+    document.title = title;
+    setContent('meta[name="description"]', description);
+    setContent('meta[property="og:title"]', title);
+    setContent('meta[property="og:description"]', description);
+    ensureMeta('meta[property="og:url"]', { property: "og:url" }).setAttribute("content", url);
+    setContent('meta[property="og:image"]', image);
+    setContent('meta[name="twitter:title"]', title);
+    setContent('meta[name="twitter:description"]', description);
+    setContent('meta[name="twitter:image"]', image);
+    ensureLink("canonical").setAttribute("href", url);
 
     return () => {
       document.title = previousTitle;
-      set('meta[name="description"]', previousDescription);
-      set('meta[property="og:title"]', previousOgTitle);
-      set('meta[property="og:description"]', previousOgDescription);
-      set('meta[name="twitter:title"]', previousTwitterTitle);
-      set('meta[name="twitter:description"]', previousTwitterDescription);
+      setContent('meta[name="description"]', previousDescription);
+      setContent('meta[property="og:title"]', previousOgTitle);
+      setContent('meta[property="og:description"]', previousOgDescription);
+      setContent('meta[property="og:url"]', previousOgUrl);
+      setContent('meta[property="og:image"]', previousOgImage);
+      setContent('meta[name="twitter:title"]', previousTwitterTitle);
+      setContent('meta[name="twitter:description"]', previousTwitterDescription);
+      setContent('meta[name="twitter:image"]', previousTwitterImage);
+      const canonical = document.querySelector('link[rel="canonical"]');
+      if (canonical) canonical.setAttribute("href", previousCanonical);
     };
   }, [title, description]);
 }

--- a/website/src/pages/Download.tsx
+++ b/website/src/pages/Download.tsx
@@ -12,34 +12,67 @@ export function Download() {
       <div className="kicker">download · v{PRODUCT.version}</div>
       <h1>official binaries from GitHub Releases.</h1>
       <p style={{ color: "var(--muted)", maxWidth: 640 }}>
-        OpenOnyx is an Electron desktop app. Grab the installer for your OS from the {PRODUCT.version} release,
-        or build from source with Node.js 22+.
+        OpenOnyx is an Electron desktop app. These buttons download the {PRODUCT.version} files from GitHub
+        Releases. You can also build from source with Node.js 22+.
       </p>
 
       <div className="download-grid">
         <article className="card">
           <h3>macOS</h3>
-          <p>.dmg and .zip from the release. Apple Silicon and Intel artifacts are produced by the macOS builder.</p>
-          <a className="btn primary" href={PRODUCT.latestRelease} target="_blank" rel="noreferrer">
-            Get macOS build
-          </a>
-          <p style={{ marginTop: 14 }}>{DOWNLOADS.macNote}</p>
+          <p>Apple Silicon and Intel .dmg from the v{PRODUCT.version} release. Zip archives are on the same page.</p>
+          <div className="card-actions">
+            <a className="btn primary" href={DOWNLOADS.files.macArmDmg}>
+              Apple Silicon .dmg
+            </a>
+            <a className="btn" href={DOWNLOADS.files.macIntelDmg}>
+              Intel .dmg
+            </a>
+          </div>
+          <p className="download-more">
+            <a href={PRODUCT.latestRelease} target="_blank" rel="noreferrer">
+              All macOS files on the release
+            </a>
+          </p>
+          <p>{DOWNLOADS.macNote}</p>
         </article>
         <article className="card">
           <h3>Windows</h3>
-          <p>NSIS and portable .exe from the release.</p>
-          <a className="btn primary" href={PRODUCT.latestRelease} target="_blank" rel="noreferrer">
-            Get Windows build
-          </a>
-          <p style={{ marginTop: 14 }}>{DOWNLOADS.windowsNote}</p>
+          <p>NSIS installer and portable .exe from the v{PRODUCT.version} release.</p>
+          <div className="card-actions">
+            <a className="btn primary" href={DOWNLOADS.files.winSetup}>
+              Windows installer
+            </a>
+            <a className="btn" href={DOWNLOADS.files.winPortable}>
+              Portable .exe
+            </a>
+          </div>
+          <p className="download-more">
+            <a href={PRODUCT.latestRelease} target="_blank" rel="noreferrer">
+              All Windows files on the release
+            </a>
+          </p>
+          <p>{DOWNLOADS.windowsNote}</p>
         </article>
         <article className="card">
           <h3>Linux</h3>
-          <p>AppImage, .deb, and Arch .pkg.tar.zst from the current release.</p>
-          <a className="btn primary" href={PRODUCT.latestRelease} target="_blank" rel="noreferrer">
-            Get Linux build
-          </a>
-          <pre style={{ marginTop: 14, fontSize: 12 }}>{DOWNLOADS.linuxInstall}</pre>
+          <p>AppImage, .deb, and Arch .pkg.tar.zst from the v{PRODUCT.version} release, or the installer script.</p>
+          <div className="card-actions">
+            <a className="btn primary" href={DOWNLOADS.files.linuxAppImage}>
+              AppImage
+            </a>
+            <a className="btn" href={DOWNLOADS.files.linuxDeb}>
+              .deb
+            </a>
+            <a className="btn" href={DOWNLOADS.files.linuxArch}>
+              Arch package
+            </a>
+          </div>
+          <p className="download-more">
+            <a href={PRODUCT.latestRelease} target="_blank" rel="noreferrer">
+              All Linux files on the release
+            </a>
+          </p>
+          <pre>{DOWNLOADS.linuxInstall}</pre>
         </article>
       </div>
 

--- a/website/src/pages/Home.tsx
+++ b/website/src/pages/Home.tsx
@@ -5,6 +5,7 @@ import { Reveal } from "../components/Reveal";
 import { ProductStory } from "../components/product/ProductStory";
 import { Workspace } from "../components/product/Workspace";
 import { FEATURES, PRODUCT, THEATER } from "../data/facts";
+import { paletteHotkeyLabel } from "../lib/hotkey";
 import { usePointerDepth, useStaggerIn } from "../lib/motion";
 import { usePageMeta } from "../lib/meta";
 
@@ -38,7 +39,7 @@ export function Home() {
               Download
             </Link>
             <button type="button" className="btn" onClick={() => window.dispatchEvent(new Event("openonyx:palette"))}>
-              Open ⌘K
+              Open {paletteHotkeyLabel()}
             </button>
           </div>
         </div>

--- a/website/src/pages/NotFound.tsx
+++ b/website/src/pages/NotFound.tsx
@@ -1,0 +1,30 @@
+import { Link } from "react-router-dom";
+import { usePageMeta } from "../lib/meta";
+
+export function NotFound() {
+  usePageMeta(
+    "Page not found — OpenOnyx",
+    "This URL is not a page on the OpenOnyx site. The product, docs, and download pages are.",
+  );
+
+  return (
+    <section className="section not-found">
+      <div className="kicker">404</div>
+      <h1>this page is not here.</h1>
+      <p style={{ color: "var(--muted)", maxWidth: 560 }}>
+        That address is not a route on this site. Unknown docs slugs go to Get going; anything else lands here.
+      </p>
+      <div className="hero-actions">
+        <Link className="btn primary" to="/">
+          Product
+        </Link>
+        <Link className="btn" to="/docs/start">
+          Docs
+        </Link>
+        <Link className="btn" to="/download">
+          Download
+        </Link>
+      </div>
+    </section>
+  );
+}

--- a/website/src/styles/global.css
+++ b/website/src/styles/global.css
@@ -786,7 +786,9 @@ html[data-theme="dark"] .docs {
   font-size: 13px;
   color: var(--docs-ink);
   margin: 0 0 16px;
-  white-space: pre;
+  white-space: pre-wrap;
+  overflow-wrap: break-word;
+  word-break: normal;
 }
 .docs-body table { width: 100%; border-collapse: collapse; font-size: 14px; margin: 8px 0 20px; background: var(--docs-paper); }
 .docs-body th, .docs-body td {
@@ -876,7 +878,29 @@ html[data-theme="dark"] .docs {
 }
 .card:hover { border-color: var(--line-strong); }
 .card .btn { align-self: flex-start; margin: 4px 0 10px; }
-.card pre { margin: 0; }
+.card-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  margin: 4px 0 10px;
+}
+.card-actions .btn { margin: 0; }
+.download-more {
+  margin: 0 0 10px;
+  font-size: 12px;
+}
+.download-more a {
+  color: var(--muted);
+  text-decoration: underline;
+  text-underline-offset: 2px;
+}
+.download-more a:hover { color: var(--text); }
+.card pre {
+  margin: 0;
+  white-space: pre-wrap;
+  overflow-wrap: break-word;
+  word-break: normal;
+}
 .card h3 { margin: 0 0 6px; font-size: 15px; }
 .card p { margin: 0 0 10px; color: var(--muted); font-size: 13px; }
 

--- a/website/vercel.json
+++ b/website/vercel.json
@@ -3,5 +3,6 @@
   "framework": "vite",
   "installCommand": "npm install",
   "buildCommand": "npm run build",
-  "outputDirectory": "dist"
+  "outputDirectory": "dist",
+  "rewrites": [{ "source": "/(.*)", "destination": "/index.html" }]
 }


### PR DESCRIPTION
## Why

A first-visit pass on the marketing site hit a blank page on unknown URLs, relative social images, download buttons that all pointed at the same tag page, a clipped Linux install command, ⌘K-only labeling on non-Mac machines, and AI/export copy that disagreed with the Spaces docs.

## What changed

- Catch-all 404 inside the site chrome, with Product / Docs / Download
- `og:image`, `twitter:image`, and canonical rewritten from `window.location.origin`. Static HTML fallback is the GitHub raw banner — not a hardcoded production host
- macOS, Windows, and Linux buttons download the real v1.0.4 artifacts (Apple Silicon / Intel `.dmg`, NSIS + portable `.exe`, AppImage / `.deb` / Arch). Each card still links the release page
- Linux and source `<pre>` wrap so the install curl is fully readable on the three-column download grid
- Palette chip says ⌘K on Apple and Ctrl+K elsewhere
- AI writing and export copy aligned with Spaces / Plugins docs. Export no longer pretends a dedicated export guide exists
- Vercel SPA rewrite so unknown paths reach the in-app 404 instead of a host 404

## Out of scope

- Docs wide-layout rail ([#125](https://github.com/OpenOnyx/OpenOnyx/pull/125))
- Desktop CSS snippets
- Inventing OS artifacts that are not on the v1.0.4 release

## Test plan

- [ ] `/this-is-not-a-route` shows the 404 with header and footer
- [ ] `/docs/not-a-real-page` still redirects to `/docs/start`
- [ ] Download buttons 302 to the matching v1.0.4 files
- [ ] Linux curl is fully visible at ~1440px (three columns) and on a phone
- [ ] Windows/Linux UA shows Ctrl+K; macOS shows ⌘K
- [ ] Home export card goes to `/docs/plugins` and does not claim a dedicated export guide